### PR TITLE
fix README "Local tty based" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ number. To do so, you can add a block of custom ssh config
 in the `~/.ssh/config` of your local machine like
 
 ```
-Host = remote
+Host = by-tty
     User remoteuser
     Hostname remote.host.example.com
 


### PR DESCRIPTION
The section on local tty based automatic connection says you can invoke the config with `ssh by-tty` but the config block is for the "remote" host so this would not work. This patch fixes the issue.