### PR TITLE
set a default prompt prefix

### DIFF
--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -43,6 +43,7 @@ use crate::daemon::exit_notify::ExitNotifier;
 const STDERR_FD: i32 = 2;
 const DEFAULT_INITIAL_SHELL_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
 const DEFAULT_OUTPUT_SPOOL_LINES: usize = 500;
+const DEFAULT_PROMPT_PREFIX: &str = "shpool:$SHPOOL_SESSION_NAME ";
 
 pub struct Server {
     config: config::Config,
@@ -626,7 +627,8 @@ impl Server {
         });
 
         // inject the prompt prefix, if any
-        let prompt_prefix = self.config.prompt_prefix.clone().unwrap_or(String::from(""));
+        let prompt_prefix =
+            self.config.prompt_prefix.clone().unwrap_or(String::from(DEFAULT_PROMPT_PREFIX));
         if let Some(shell_basename) = shell_basename {
             if !prompt_prefix.is_empty() {
                 if let Err(err) =

--- a/shpool/tests/data/custom_detach_keybinding.toml
+++ b/shpool/tests/data/custom_detach_keybinding.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/disable_symlink_ssh_auth_sock.toml
+++ b/shpool/tests/data/disable_symlink_ssh_auth_sock.toml
@@ -3,6 +3,7 @@ noecho = true
 shell = "/bin/bash"
 nosymlink_ssh_auth_sock = true
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/forward_env.toml
+++ b/shpool/tests/data/forward_env.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 forward_env = ["FOO", "BAR"]
 

--- a/shpool/tests/data/long_noop_keybinding.toml
+++ b/shpool/tests/data/long_noop_keybinding.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/no_etc_environment.toml
+++ b/shpool/tests/data/no_etc_environment.toml
@@ -3,6 +3,7 @@ noecho = true
 noread_etc_environment = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/norc.toml
+++ b/shpool/tests/data/norc.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/restore_lines.toml
+++ b/shpool/tests/data/restore_lines.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = { lines = 2 }
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/restore_many_lines.toml
+++ b/shpool/tests/data/restore_many_lines.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = { lines = 5000 }
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/restore_screen.toml
+++ b/shpool/tests/data/restore_screen.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "screen"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/data/user_env.toml
+++ b/shpool/tests/data/user_env.toml
@@ -2,6 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "simple"
+prompt_prefix = ""
 
 [env]
 PS1 = "prompt> "


### PR DESCRIPTION
The 'prompt_prefix' option has had a while to bake and I have not gotten any bikeshedding suggestions beyond the one I've been using, so this patch
sets a new default prompt prefix. Users should no
longer need to worry about adding shell config to
make their prompt indicate they are in a shpool
session, they should get it for free from now on.

This change can be disabled by setting prompt_prefix="" in the config file.