### PR TITLE
add motd pager mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +391,7 @@ dependencies = [
  "libc",
  "log",
  "motd",
- "nix",
+ "nix 0.28.0",
  "ntest",
  "serde",
  "serde_derive",
@@ -393,6 +399,8 @@ dependencies = [
  "shpool_pty",
  "shpool_vt100",
  "signal-hook",
+ "strip-ansi-escapes",
+ "tempfile",
  "termini",
  "toml",
  "tracing",
@@ -427,6 +435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "motd"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,8 +471,21 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -676,7 +706,7 @@ dependencies = [
  "lazy_static",
  "libshpool",
  "motd",
- "nix",
+ "nix 0.26.4",
  "ntest",
  "regex",
  "serde_json",
@@ -685,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "shpool_pty"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3849a4f8fce2d81201c38dc662495f37bef2609e4474ad7dc8b76e44a136040"
+checksum = "01fbec35414044d1f92bfa2d8eb7faf6e658fb10eae3440e169e5a36c5969ab5"
 dependencies = [
  "errno 0.2.8",
  "libc",
@@ -703,7 +733,7 @@ dependencies = [
  "itoa",
  "log",
  "unicode-width",
- "vte",
+ "vte 0.12.1",
 ]
 
 [[package]]
@@ -730,6 +760,15 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte 0.11.1",
+]
 
 [[package]]
 name = "strsim"
@@ -914,6 +953,16 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
 
 [[package]]
 name = "vte"

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -27,8 +27,7 @@ serde_derive = "1" # config parsing, connection header formatting
 toml = "0.7" # config parsing
 byteorder = "1" # endianness
 signal-hook = "0.3" # signal handling
-nix = { version = "0.26", features = ["poll", "ioctl"] } # rusty wrapper for unix apis
-shpool_pty = "0.3.0" # spawning shells in ptys
+shpool_pty = "0.3.1" # spawning shells in ptys
 lazy_static = "1" # globals
 crossbeam-channel = "0.5" # channels
 libc = "0.2" # basic libc types
@@ -39,6 +38,13 @@ shpool_vt100 = "0.1.2" # terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
 motd = "0.2.0" # getting the message-of-the-day
 termini = "1.0.0" # terminfo database
+tempfile = "3" # RAII tmp files
+strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display
+
+# rusty wrapper for unix apis
+[dependencies.nix]
+version = "0.28"
+features = ["poll", "ioctl", "socket", "user", "process", "signal", "term", "fs"]
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/libshpool/src/config.rs
+++ b/libshpool/src/config.rs
@@ -170,8 +170,8 @@ pub enum MotdDisplayMode {
     /// Display the message of the day each time a user attaches
     /// (wether to a new session or reattaching to an existing session).
     ///
-    /// `less` by default.
-    // Pager(String),
+    /// Typically bin is set to `"less"` if you want to use this option.
+    Pager { bin: String },
 
     /// Just dump the message of the day directly to the screen.
     /// Dumps are only performed when a new session is created.

--- a/libshpool/src/consts.rs
+++ b/libshpool/src/consts.rs
@@ -20,3 +20,6 @@ pub const JOIN_POLL_DURATION: time::Duration = time::Duration::from_millis(100);
 pub const BUF_SIZE: usize = 1024 * 16;
 
 pub const HEARTBEAT_DURATION: time::Duration = time::Duration::from_millis(500);
+
+pub const STDIN_FD: i32 = 0;
+pub const STDERR_FD: i32 = 2;

--- a/libshpool/src/daemon/mod.rs
+++ b/libshpool/src/daemon/mod.rs
@@ -23,6 +23,7 @@ mod control_codes;
 mod etc_environment;
 mod exit_notify;
 pub mod keybindings;
+mod pager;
 mod prompt;
 mod server;
 mod shell;

--- a/libshpool/src/daemon/pager.rs
+++ b/libshpool/src/daemon/pager.rs
@@ -1,0 +1,390 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+  The pager module contains code for lauching a pager program
+  such as 'less' in a background pty to display a particular
+  message. This is essentially a mini version of the main shell
+  loop, except that the only type of process it will launch is
+  a pager, and there is no session persistence. We choose to
+  re-implement a bunch of functionality instead of trying to
+  re-use code because the normal shell loop has a lot of complex
+  control code due to session persistence concerns and rather
+  than dealing with adding even more conditions to the normal
+  codepaths it seems better to have a simple and self-contained
+  implementation in a dedicated module.
+
+  This is used for displaying the motd in pager mode, though it
+  works as a general out-of-band message display mechanism
+  so it could potentially be used for something else in the future.
+*/
+
+use std::{
+    io,
+    io::{Read, Write},
+    os::{
+        fd::AsFd,
+        unix::{net::UnixStream, process::CommandExt},
+    },
+    process,
+    sync::atomic::{AtomicBool, Ordering},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context};
+use nix::{poll, sys::signal, unistd};
+use tracing::{error, info, instrument, span, trace, warn, Level};
+
+use crate::{consts, protocol, tty};
+
+// poll relatively quickly to pick up pager exits reasonably fast,
+// but still slow enough to spend most of the time parked.
+const POLL_MS: u16 = 100;
+
+// Handles for poking at the pager from separate connection handlers.
+// This is basically the same idea as for ReaderCtl.
+#[derive(Debug)]
+pub struct PagerCtl {
+    /// Used to signal size changes so we can correctly trigger
+    /// a SIGWINCH on the pty.
+    pub tty_size_change: crossbeam_channel::Sender<tty::Size>,
+    /// Acks the completion of a resize/SIGWINCH.
+    pub tty_size_change_ack: crossbeam_channel::Receiver<()>,
+}
+
+/// Pager is capable of displaying a message to the user via
+/// the pager of their choice. Display will block until they
+/// quick or the connection drops.
+pub struct Pager {
+    /// The name of the pager program to use. Typically "less".
+    pager_bin: String,
+}
+
+impl Pager {
+    /// Create a new Pager.
+    pub fn new(pager_bin: String) -> Self {
+        Pager { pager_bin }
+    }
+
+    /// Display the message, blocking until the user quits
+    /// out of the pager process or the connection drops.
+    ///
+    /// Though this returns any anyhow::Result, you likely want to
+    /// downcast any errors to check to see if you got a PagerError,
+    /// since some error conditions ought to be handled by the caller.
+    /// In particular, you can't assume that the client_stream is still
+    /// healthy after a call to display() and you should check for
+    /// PagerError::ClientHangup to determine if you should continue
+    /// on with the connection.
+    ///
+    /// On success, returns the final tty size, since the user may
+    /// have resized their terminal while looking at the pager.
+    #[instrument(skip_all)]
+    pub fn display(
+        &self,
+        // The client connection on which to display the pager.
+        client_stream: &mut UnixStream,
+        // The slot to install the control handle in
+        ctl_slot: Arc<Mutex<Option<PagerCtl>>>,
+        // The size of the tty to start off with
+        init_tty_size: tty::Size,
+        // The message to display
+        msg: &str,
+    ) -> anyhow::Result<tty::Size> {
+        let (tty_size_change_tx, tty_size_change_rx) = crossbeam_channel::bounded(0);
+        let (tty_size_change_ack_tx, tty_size_change_ack_rx) = crossbeam_channel::bounded(0);
+        {
+            let mut ctl_handle = ctl_slot.lock().unwrap();
+            if ctl_handle.is_some() {
+                return Err(anyhow!("only one pager per session at a time allowed"));
+            }
+
+            trace!("registering PagerCtl");
+            *ctl_handle = Some(PagerCtl {
+                tty_size_change: tty_size_change_tx,
+                tty_size_change_ack: tty_size_change_ack_rx,
+            });
+        }
+        // make sure we reset the control handles
+        let _ctl_guard = PagerCltGuard { ctl_slot };
+
+        let mut msg_file = tempfile::NamedTempFile::with_prefix("shpool_pager")
+            .context("creating tmp file to display msg via pager")?;
+        let cleaned_msg = strip_ansi_escapes::strip(msg);
+        msg_file.write_all(cleaned_msg.as_slice()).context("writing msg to tmp pager file")?;
+
+        let mut cmd = process::Command::new(&self.pager_bin);
+        cmd.arg(msg_file.path().as_os_str());
+
+        // fork, leaving us with a handle in the master branch
+        // and execing the pty wrapped pager in the child.
+        info!("forking pager pty proc");
+        let fork = shpool_pty::fork::Fork::from_ptmx().context("forking pty")?;
+        if fork.is_child().is_ok() {
+            for fd in consts::STDERR_FD + 1..(nix::unistd::SysconfVar::OPEN_MAX as i32) {
+                let _ = nix::unistd::close(fd);
+            }
+            let err = cmd.exec();
+            eprintln!("pager exec err: {:?}", err);
+            std::process::exit(1);
+        }
+        let pager_exited = Arc::new(AtomicBool::new(false));
+        let _proc_guard =
+            PagerProcGuard { pager_proc: &fork, pager_exited: Arc::clone(&pager_exited) };
+
+        let pager_exited_ref = Arc::clone(&pager_exited);
+        let waitable_child = fork.clone();
+        thread::spawn(move || {
+            let _s = span!(Level::INFO, "pager_exit_monitor").entered();
+            match waitable_child.wait_for_exit() {
+                Ok((_, Some(exit_status))) => {
+                    info!("child pager exited with status {}", exit_status);
+                    pager_exited_ref.store(true, Ordering::Relaxed);
+                }
+                Ok((_, None)) => {
+                    info!("child pager exited without status");
+                    pager_exited_ref.store(true, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    info!("error waiting on pager child: {:?}", e);
+                    pager_exited_ref.store(true, Ordering::Relaxed);
+                }
+            }
+            info!("reaped child pager: {:?}", waitable_child);
+        });
+
+        let mut pty_master = fork.is_parent().context("getting pty_master handle")?;
+
+        // spawn a background thread to handle tty size change events,
+        // setting it up to go away when _ctl_guard removes the ctl
+        // handle.
+        let pty_master_fd = pty_master.raw_fd().ok_or(anyhow!("no fd for pty master"))?;
+        init_tty_size.set_fd(pty_master_fd).context("setting init tty size")?;
+        let tty_size = Arc::new(Mutex::new(init_tty_size.clone()));
+        let tty_size_ref = Arc::clone(&tty_size);
+        info!("spawning pager size change listener");
+        thread::spawn(move || {
+            let _s = span!(Level::INFO, "pager_size_change").entered();
+
+            // We could also set things up to handle detach commands, but
+            // since pagers don't stick around when the client hangs up
+            // it is not really that importaint. Let's KISS.
+            while let Ok(size) = tty_size_change_rx.recv() {
+                if let Err(e) = size.set_fd(pty_master_fd) {
+                    warn!("setting pager size: {:?}", e);
+                }
+
+                {
+                    // register the new size so it will get returned
+                    let mut tty_size = tty_size_ref.lock().unwrap();
+                    *tty_size = size;
+                }
+
+                if let Err(e) = tty_size_change_ack_tx.send(()) {
+                    error!("could not send size change ack: {:?}", e);
+                    break;
+                }
+            }
+            info!("pager size change loop done");
+        });
+
+        let mut last_heartbeat_at = Instant::now();
+        let mut buf = vec![0; consts::BUF_SIZE];
+        let watchable_master = pty_master;
+        let watchable_client_stream =
+            client_stream.try_clone().context("could not clone client stream")?;
+        loop {
+            // wake up when there is data for us going in either direction
+            let mut poll_fds = [
+                poll::PollFd::new(
+                    watchable_master.borrow_fd().ok_or(anyhow!("no master fd"))?,
+                    poll::PollFlags::POLLIN,
+                ),
+                poll::PollFd::new(watchable_client_stream.as_fd(), poll::PollFlags::POLLIN),
+            ];
+            let nready = poll::poll(&mut poll_fds, POLL_MS).context("polling both streams")?;
+            if pager_exited.load(Ordering::Relaxed) {
+                let tty_size = tty_size.lock().unwrap();
+                return Ok(tty_size.clone());
+            }
+            if nready == 0 {
+                // if timeout
+                let now = Instant::now();
+                if now
+                    .checked_duration_since(
+                        last_heartbeat_at
+                            .checked_add(consts::HEARTBEAT_DURATION)
+                            .ok_or(anyhow!("could not add to dur"))?,
+                    )
+                    .is_some()
+                {
+                    last_heartbeat_at = now;
+
+                    let chunk = protocol::Chunk { kind: protocol::ChunkKind::Heartbeat, buf: &[] };
+                    match chunk.write_to(client_stream).and_then(|_| client_stream.flush()) {
+                        Ok(_) => {
+                            trace!("wrote heartbeat");
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                            trace!("client hangup writing heartbeat: {:?}", e);
+                            return Err(PagerError::ClientHangup)?;
+                        }
+                        Err(e) => {
+                            return Err(e).context("writing heartbeat")?;
+                        }
+                    }
+                }
+            } else {
+                // -1 case should have been turned into an error already
+                assert!(nready > 0);
+                let pty_master_poll_fd = &poll_fds[0];
+                let client_stream_poll_fd = &poll_fds[1];
+
+                if pty_master_poll_fd.any().unwrap_or(false) {
+                    // the pager process has some data for us
+                    let len = pty_master.read(&mut buf).context("reading chunk from pty master")?;
+                    let chunk =
+                        protocol::Chunk { kind: protocol::ChunkKind::Data, buf: &buf[..len] };
+                    match chunk.write_to(client_stream).and_then(|_| client_stream.flush()) {
+                        Ok(_) => {}
+                        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                            trace!("client hangup writing data chunk: {:?}", e);
+                            return Err(PagerError::ClientHangup)?;
+                        }
+                        Err(e) => {
+                            return Err(e).context("writing data chunk")?;
+                        }
+                    }
+                }
+
+                if client_stream_poll_fd.any().unwrap_or(false) {
+                    let len = client_stream.read(&mut buf).context("reading client chunk")?;
+                    if len == 0 {
+                        continue;
+                    }
+
+                    trace!("user input: {}", String::from_utf8_lossy(&buf[..len]));
+
+                    if let Err(e) = pty_master.write_all(&buf[0..len]) {
+                        info!("Error writing to pager pty, nbd though: {:?}", e);
+                        // assume the pager proc just quit normally and the
+                        // timing was such that we didn't pick it up with our
+                        // exit watcher thread.
+                        let tty_size = tty_size.lock().unwrap();
+                        return Ok(tty_size.clone());
+                    }
+                    if let Err(e) = pty_master.flush() {
+                        info!("Error flushing pager pty, nbd though: {:?}", e);
+                        // same logic as above
+                        let tty_size = tty_size.lock().unwrap();
+                        return Ok(tty_size.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
+// An RAII guard to make sure that we reset the pager_ctl
+// slot in the session struct.
+struct PagerCltGuard {
+    ctl_slot: Arc<Mutex<Option<PagerCtl>>>,
+}
+
+impl std::ops::Drop for PagerCltGuard {
+    fn drop(&mut self) {
+        let mut pager_ctl = self.ctl_slot.lock().unwrap();
+        // N.B. clobbering the handles here will cause the listening
+        // thread to exit because it drops the senders. This ensures
+        // that no callers can grab the lock on the ctl handles and
+        // then make a call when no one is listening.
+        *pager_ctl = None;
+        trace!("deregistered PagerCtl");
+    }
+}
+
+/// An RAII guard to make sure that the pager process is for
+/// sure gone by the time the display routine exits.
+struct PagerProcGuard<'pager> {
+    pager_proc: &'pager shpool_pty::fork::Fork,
+    /// Used to make sure we don't try to kill the child proc
+    /// if it has already exited on its own.
+    pager_exited: Arc<AtomicBool>,
+}
+
+impl<'pager> std::ops::Drop for PagerProcGuard<'pager> {
+    fn drop(&mut self) {
+        if self.pager_exited.load(Ordering::Relaxed) {
+            // our work here is done
+            return;
+        }
+
+        if let Err(e) = self.kill() {
+            error!("Error cleaning up pager proc: {:?}", e);
+        }
+    }
+}
+
+impl<'pager> PagerProcGuard<'pager> {
+    fn kill(&self) -> anyhow::Result<()> {
+        let pid = if let shpool_pty::fork::Fork::Parent(pid, _) = self.pager_proc {
+            *pid
+        } else {
+            return Err(anyhow!("somehow have a child pty handle in the main proc"));
+        };
+
+        // first we'll be polite and give a SIGTERM
+        signal::kill(unistd::Pid::from_raw(pid), Some(signal::Signal::SIGTERM))
+            .context("sending SIGTERM to pager proc")?;
+
+        // now do an exponential backoff for
+        // `sum(10*(2**x) for x in range(7))` = 1270 ms = ~1.2 s
+        // to see if that worked
+        let mut sleep_ms = 10;
+        for _ in 0..7 {
+            if self.pager_exited.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(sleep_ms));
+            sleep_ms *= 2;
+        }
+
+        // now we are done asking
+        signal::kill(unistd::Pid::from_raw(pid), Some(signal::Signal::SIGKILL))
+            .context("sending SIGKILL to pager proc")?;
+
+        // and we won't stick around to see if that worked because we
+        // have no further way to escalate
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PagerError {
+    /// Indicates that the client stream was closed by the client
+    /// while we were showing them the pager.
+    ClientHangup,
+}
+
+impl std::fmt::Display for PagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)?;
+        Ok(())
+    }
+}
+
+impl std::error::Error for PagerError {}

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -13,14 +13,14 @@ use regex::Regex;
 
 mod support;
 
-use crate::support::daemon::AttachArgs;
+use crate::support::daemon::{AttachArgs, DaemonArgs};
 
 #[test]
 #[timeout(30000)]
 fn happy_path() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
 
@@ -54,8 +54,8 @@ fn happy_path() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn custom_cmd() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let script = support::testdata_file("echo_stop.sh");
         let mut attach_proc = daemon_proc
             .attach(
@@ -86,8 +86,8 @@ fn custom_cmd() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn forward_env() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("forward_env.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("forward_env.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc = daemon_proc
             .attach(
                 "sh1",
@@ -116,8 +116,8 @@ fn forward_env() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn symlink_ssh_auth_sock() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-wrote-s2c-chunk"]);
 
         let fake_auth_sock_tgt = daemon_proc.tmp_dir.join("ssh-auth-sock-target.fake");
@@ -151,8 +151,8 @@ fn symlink_ssh_auth_sock() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn missing_ssh_auth_sock() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-wrote-s2c-chunk"]);
 
         let fake_auth_sock_tgt = daemon_proc.tmp_dir.join("ssh-auth-sock-target.fake");
@@ -175,8 +175,8 @@ fn missing_ssh_auth_sock() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn fresh_shell_draws_prompt() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
@@ -198,7 +198,7 @@ fn fresh_shell_draws_prompt() -> anyhow::Result<()> {
 fn config_disable_symlink_ssh_auth_sock() -> anyhow::Result<()> {
     support::dump_err(|| {
         let mut daemon_proc =
-            support::daemon::Proc::new("disable_symlink_ssh_auth_sock.toml", true)
+            support::daemon::Proc::new("disable_symlink_ssh_auth_sock.toml", DaemonArgs::default())
                 .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-wrote-s2c-chunk"]);
 
@@ -234,8 +234,8 @@ fn config_disable_symlink_ssh_auth_sock() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn bounce() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
         {
@@ -271,8 +271,8 @@ fn bounce() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn two_at_once() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut attach_proc1 =
             daemon_proc.attach("sh1", Default::default()).context("starting sh1")?;
@@ -298,8 +298,8 @@ fn two_at_once() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn explicit_exit() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
         {
@@ -340,8 +340,8 @@ fn explicit_exit() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn exit_immediate_drop() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc.events.take().unwrap().waiter([
             "daemon-read-c2s-chunk",
@@ -395,8 +395,11 @@ fn exit_immediate_drop() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn output_flood() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
 
@@ -418,8 +421,11 @@ fn output_flood() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn force_attach() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
 
         let mut tty1 =
             daemon_proc.attach("sh1", Default::default()).context("attaching from tty1")?;
@@ -445,8 +451,11 @@ fn force_attach() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn busy() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
 
         let mut tty1 =
             daemon_proc.attach("sh1", Default::default()).context("attaching from tty1")?;
@@ -467,8 +476,11 @@ fn busy() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn daemon_hangup() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
 
@@ -490,8 +502,8 @@ fn daemon_hangup() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn default_keybinding_detach() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         let mut a1 =
@@ -524,8 +536,8 @@ fn default_keybinding_detach() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn keybinding_input_shear() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         let mut a1 =
@@ -558,8 +570,11 @@ fn keybinding_input_shear() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn keybinding_strip_keys() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("long_noop_keybinding.toml", false)
-            .context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "long_noop_keybinding.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut a1 =
             daemon_proc.attach("sess", Default::default()).context("starting attach proc")?;
         let mut lm1 = a1.line_matcher()?;
@@ -576,8 +591,11 @@ fn keybinding_strip_keys() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn keybinding_strip_keys_split() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("long_noop_keybinding.toml", false)
-            .context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "long_noop_keybinding.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut a1 =
             daemon_proc.attach("sess", Default::default()).context("starting attach proc")?;
         let mut lm1 = a1.line_matcher()?;
@@ -598,8 +616,11 @@ fn keybinding_strip_keys_split() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn keybinding_partial_match_nostrip() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("long_noop_keybinding.toml", false)
-            .context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "long_noop_keybinding.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut a1 =
             daemon_proc.attach("sess", Default::default()).context("starting attach proc")?;
         let mut lm1 = a1.line_matcher()?;
@@ -616,8 +637,11 @@ fn keybinding_partial_match_nostrip() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn keybinding_partial_match_nostrip_split() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("long_noop_keybinding.toml", false)
-            .context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "long_noop_keybinding.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let mut a1 =
             daemon_proc.attach("sess", Default::default()).context("starting attach proc")?;
         let mut lm1 = a1.line_matcher()?;
@@ -638,8 +662,9 @@ fn keybinding_partial_match_nostrip_split() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn custom_keybinding_detach() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("custom_detach_keybinding.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("custom_detach_keybinding.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         let mut a1 =
@@ -670,8 +695,8 @@ fn custom_keybinding_detach() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn injects_term_even_with_env_config() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("user_env.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("user_env.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut waiter = daemon_proc.events.take().unwrap().waiter(["daemon-wrote-s2c-chunk"]);
 
         let mut attach_proc = daemon_proc
@@ -701,8 +726,8 @@ fn injects_term_even_with_env_config() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn injects_local_env_vars() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc = daemon_proc
             .attach(
                 "sh1",
@@ -731,8 +756,9 @@ fn injects_local_env_vars() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn has_right_default_path() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("no_etc_environment.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("no_etc_environment.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
 
@@ -749,8 +775,9 @@ fn has_right_default_path() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn screen_restore() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("restore_screen.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("restore_screen.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         {
@@ -784,8 +811,9 @@ fn screen_restore() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn screen_wide_restore() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("restore_screen.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("restore_screen.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         {
@@ -819,8 +847,9 @@ fn screen_wide_restore() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn lines_restore() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("restore_lines.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("restore_lines.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         {
@@ -858,8 +887,9 @@ fn lines_restore() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn lines_big_chunk_restore() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc = support::daemon::Proc::new("restore_many_lines.toml", true)
-            .context("starting daemon proc")?;
+        let mut daemon_proc =
+            support::daemon::Proc::new("restore_many_lines.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
 
         // BUF_SIZE from src/consts.rs
@@ -905,8 +935,8 @@ fn lines_big_chunk_restore() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn exits_with_same_status_as_shell() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc =
             daemon_proc.attach("sh", Default::default()).context("starting attach proc")?;
 
@@ -930,8 +960,8 @@ fn exits_with_same_status_as_shell() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn ttl_hangup() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc = daemon_proc
             .attach(
                 "sh1",
@@ -958,8 +988,8 @@ fn ttl_hangup() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn ttl_no_hangup_yet() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut attach_proc = daemon_proc
             .attach(
                 "sh1",
@@ -983,8 +1013,9 @@ fn ttl_no_hangup_yet() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn prompt_prefix_bash() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let daemon_proc = support::daemon::Proc::new("prompt_prefix_bash.toml", true)
-            .context("starting daemon proc")?;
+        let daemon_proc =
+            support::daemon::Proc::new("prompt_prefix_bash.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
 
         // we have to manually spawn the child proc rather than using the support
         // util because the line matcher gets bound only after the process gets
@@ -1026,8 +1057,9 @@ fn prompt_prefix_bash() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn prompt_prefix_zsh() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let daemon_proc = support::daemon::Proc::new("prompt_prefix_zsh.toml", true)
-            .context("starting daemon proc")?;
+        let daemon_proc =
+            support::daemon::Proc::new("prompt_prefix_zsh.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
 
         // see the bash case for why
         let mut child = Command::new(support::shpool_bin()?)
@@ -1066,8 +1098,9 @@ fn prompt_prefix_zsh() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn prompt_prefix_fish() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let daemon_proc = support::daemon::Proc::new("prompt_prefix_fish.toml", true)
-            .context("starting daemon proc")?;
+        let daemon_proc =
+            support::daemon::Proc::new("prompt_prefix_fish.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
 
         // see the bash case for why
         let mut child = Command::new(support::shpool_bin()?)
@@ -1130,8 +1163,8 @@ fn motd_dump() -> anyhow::Result<()> {
         }
 
         // spawn a daemon based on our custom config
-        let daemon_proc =
-            support::daemon::Proc::new(&config_file, true).context("starting daemon proc")?;
+        let daemon_proc = support::daemon::Proc::new(&config_file, DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         // We need to manually spawn our attach proc because
         // the motd gets printed immediately, so we can't always
@@ -1162,8 +1195,86 @@ fn motd_dump() -> anyhow::Result<()> {
         let mut stdout_str = String::from("");
         stdout.read_to_string(&mut stdout_str).context("slurping stdout")?;
         let stdout_re = Regex::new(".*MOTD_MSG.*")?;
-        // eprintln!("stdout_str='{}'", stdout_str);
         assert!(stdout_re.is_match(&stdout_str));
+
+        Ok(())
+    })
+}
+
+#[test]
+#[timeout(30000)]
+fn motd_pager() -> anyhow::Result<()> {
+    support::dump_err(|| {
+        // set up the config
+        let tmp_dir = tempfile::TempDir::with_prefix("shpool-test-config")?;
+        let tmp_dir_path = if env::var("SHPOOL_LEAVE_TEST_LOGS").is_ok() {
+            // leave the tmp files around for later inspection if we have been asked
+            // to leave the logs in place.
+            tmp_dir.into_path()
+        } else {
+            PathBuf::from(tmp_dir.path())
+        };
+        eprintln!("building config in {:?}", tmp_dir_path);
+        let motd_file = tmp_dir_path.join("motd.txt");
+        {
+            let mut f = fs::File::create(&motd_file)?;
+            f.write_all("MOTD_MSG\n".as_bytes())?;
+        }
+        let config_tmpl = fs::read_to_string(support::testdata_file("motd_pager.toml.tmpl"))?;
+        let config_contents = config_tmpl.replace("TMP_MOTD_MSG_FILE", motd_file.to_str().unwrap());
+        let config_file = tmp_dir_path.join("motd_pager.toml");
+        {
+            let mut f = fs::File::create(&config_file)?;
+            f.write_all(config_contents.as_bytes())?;
+        }
+
+        // spawn a daemon based on our custom config
+        let daemon_proc = support::daemon::Proc::new(
+            &config_file,
+            DaemonArgs {
+                extra_env: vec![(String::from("TERM"), String::from("xterm"))],
+                ..DaemonArgs::default()
+            },
+        )
+        .context("starting daemon proc")?;
+
+        // We need to manually spawn our attach proc because
+        // the motd gets printed immediately, so we can't always
+        // attach a line matcher in time.
+        let mut child = Command::new(support::shpool_bin()?)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .arg("--socket")
+            .arg(&daemon_proc.socket_path)
+            .arg("--config-file")
+            .arg(config_file)
+            .arg("attach")
+            .arg("sh1")
+            .spawn()
+            .context("spawning attach process")?;
+
+        // The attach shell should be spawned and have read the
+        // initial prompt after half a second.
+        std::thread::sleep(time::Duration::from_millis(500));
+        child.kill().context("killing child")?;
+
+        let mut stderr = child.stderr.take().context("missing stderr")?;
+        let mut stderr_str = String::from("");
+        stderr.read_to_string(&mut stderr_str).context("slurping stderr")?;
+        assert!(stderr_str.is_empty());
+
+        let mut stdout = child.stdout.take().context("missing stdout")?;
+        let mut stdout_str = String::from("");
+        stdout.read_to_string(&mut stdout_str).context("slurping stdout")?;
+        let stdout_msg_re = Regex::new(".*MOTD_MSG.*")?;
+        eprintln!("stdout_str: {}", stdout_str);
+        assert!(stdout_msg_re.is_match(&stdout_str));
+
+        // Less includes the name of the file in its output, so we test
+        // for the presence of the stem used to contrust the tmp file
+        // passed to the pager.
+        let stdout_file_re = Regex::new(".*\\(END\\).*")?;
+        assert!(stdout_file_re.is_match(&stdout_str));
 
         Ok(())
     })
@@ -1172,8 +1283,11 @@ fn motd_dump() -> anyhow::Result<()> {
 #[ignore] // TODO: re-enable, this test if flaky
 #[test]
 fn up_arrow_no_crash() -> anyhow::Result<()> {
-    let mut daemon_proc =
-        support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+    let mut daemon_proc = support::daemon::Proc::new(
+        "norc.toml",
+        DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+    )
+    .context("starting daemon proc")?;
     let mut attach_proc =
         daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
 

--- a/shpool/tests/daemon.rs
+++ b/shpool/tests/daemon.rs
@@ -21,6 +21,8 @@ use regex::Regex;
 
 mod support;
 
+use crate::support::daemon::DaemonArgs;
+
 #[test]
 #[timeout(30000)]
 fn start() -> anyhow::Result<()> {
@@ -251,8 +253,11 @@ fn hooks() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn cleanup_socket() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
 
         signal::kill(
             Pid::from_raw(daemon_proc.proc.as_ref().unwrap().id() as i32),

--- a/shpool/tests/data/motd_pager.toml.tmpl
+++ b/shpool/tests/data/motd_pager.toml.tmpl
@@ -1,0 +1,13 @@
+norc = true
+noecho = true
+shell = "/bin/bash"
+session_restore_mode = "simple"
+
+motd_args = ["motd=TMP_MOTD_MSG_FILE"]
+
+[motd.pager]
+bin = "less"
+
+[env]
+PS1 = "prompt> "
+TERM = "xterm"

--- a/shpool/tests/detach.rs
+++ b/shpool/tests/detach.rs
@@ -5,12 +5,14 @@ use ntest::timeout;
 
 mod support;
 
+use crate::support::daemon::DaemonArgs;
+
 #[test]
 #[timeout(30000)]
 fn single_running() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -40,8 +42,11 @@ fn single_running() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn single_not_running() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
 
         let out = daemon_proc.detach(vec![String::from("sh1")])?;
         assert!(!out.status.success(), "successful");
@@ -80,8 +85,8 @@ fn no_daemon() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn running_env_var() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -117,8 +122,8 @@ fn running_env_var() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn reattach() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
         let mut sess1 =
@@ -153,8 +158,8 @@ fn reattach() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn multiple_running() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc.events.take().unwrap().waiter([
             "daemon-bidi-stream-enter",
@@ -189,8 +194,8 @@ fn multiple_running() -> anyhow::Result<()> {
 #[test]
 fn multiple_mixed() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -219,8 +224,8 @@ fn multiple_mixed() -> anyhow::Result<()> {
 #[test]
 fn double_tap() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events

--- a/shpool/tests/kill.rs
+++ b/shpool/tests/kill.rs
@@ -5,6 +5,8 @@ use ntest::timeout;
 
 mod support;
 
+use crate::support::daemon::DaemonArgs;
+
 #[test]
 #[timeout(30000)]
 fn no_daemon() -> anyhow::Result<()> {
@@ -29,8 +31,11 @@ fn no_daemon() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn empty() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
 
         env::remove_var("SHPOOL_SESSION_NAME");
 
@@ -49,8 +54,8 @@ fn empty() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn single_attached() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let waiter = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
         let _attach_proc =
@@ -74,8 +79,8 @@ fn single_attached() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn multiple_attached() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -106,8 +111,8 @@ fn multiple_attached() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn reattach_after_kill() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -148,8 +153,8 @@ fn reattach_after_kill() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn single_detached() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -180,8 +185,8 @@ fn single_detached() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn multiple_detached() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc.events.take().unwrap().waiter([
             "daemon-bidi-stream-enter",
@@ -218,8 +223,8 @@ fn multiple_detached() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn multiple_mixed() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc.events.take().unwrap().waiter([
             "daemon-bidi-stream-enter",
@@ -256,8 +261,8 @@ fn multiple_mixed() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn running_env_var() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let mut waiter = daemon_proc
             .events
@@ -293,8 +298,8 @@ fn running_env_var() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn missing() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
 
         let out = daemon_proc.kill(vec![String::from("missing")])?;
         assert!(!out.status.success());

--- a/shpool/tests/list.rs
+++ b/shpool/tests/list.rs
@@ -6,12 +6,17 @@ use regex::Regex;
 
 mod support;
 
+use crate::support::daemon::DaemonArgs;
+
 #[test]
 #[timeout(30000)]
 fn empty() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", false).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
         let out = daemon_proc.list()?;
         assert!(out.status.success(), "list proc did not exit successfully");
 
@@ -50,8 +55,8 @@ fn no_daemon() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn one_session() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let bidi_enter_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
 
         let _sess1 = daemon_proc.attach("sh1", Default::default())?;
@@ -75,8 +80,8 @@ fn one_session() -> anyhow::Result<()> {
 #[timeout(30000)]
 fn two_sessions() -> anyhow::Result<()> {
     support::dump_err(|| {
-        let mut daemon_proc =
-            support::daemon::Proc::new("norc.toml", true).context("starting daemon proc")?;
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
         let mut bidi_enter_w = daemon_proc.events.take().unwrap().waiter([
             "daemon-bidi-stream-enter",
             "daemon-bidi-stream-enter",


### PR DESCRIPTION
This is chained on https://github.com/shell-pool/shpool/pull/6, I'll rebase before merging

    This patch adds a new pager mode for displaying the
    motd. The difference between the normal dump mode
    and the pager mode is that the pager will always
    display the motd, regardless of if a user is making
    a new session or reattaching to an old session.

    Rather than using Pager(String) for the enum variant
    I decided to go with a slightly more verbose struct
    enum variant so that there is room to add more options
    to this mode. I'm anticipating that users may want
    something like the ability to set a cooldown time
    so that this does not trigger on every reattach, but
    does trigger on the first reattach done in a day.
    For now, I'm not including any such options, but I
    want to be able to add them in a backwards compatible
    way