### PR TITLE
forward {x,y}pixel in term size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,29 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "dlopen2"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1297103d2bbaea85724fcee6294c2d50b1081f9ad47d0f6f6f61eda65315a6"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,20 +422,13 @@ dependencies = [
 
 [[package]]
 name = "motd"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b1327b3888ed1ed4b1f0ba708f1e5c4f66b6140a5816792fe05f643c3efc9d"
+checksum = "8e7d3038c0381e2d91295f07a042809979755365c3ae4decef81936f8ba49408"
 dependencies = [
- "dlopen2",
- "lazy_static",
- "libc",
  "log",
- "pam-sys",
  "serde",
  "serde_derive",
- "serde_json",
- "tempfile",
- "walkdir",
  "which",
 ]
 
@@ -535,15 +505,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "pam-sys"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4858311a097f01a0006ef7d0cd50bca81ec430c949d7bf95cbefd202282434"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -633,15 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,7 +657,6 @@ dependencies = [
  "crossbeam-channel",
  "lazy_static",
  "libshpool",
- "motd",
  "nix 0.26.4",
  "ntest",
  "regex",
@@ -986,16 +937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,15 +1018,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -36,7 +36,7 @@ tracing = "0.1" # logging and performance monitoring facade
 bincode = "1" # serialization for the control protocol
 shpool_vt100 = "0.1.2" # terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
-motd = "0.2.0" # getting the message-of-the-day
+motd = { version = "0.2.1", default-features = false, features = [] } # getting the message-of-the-day
 termini = "1.0.0" # terminfo database
 tempfile = "3" # RAII tmp files
 strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display

--- a/libshpool/src/attach.rs
+++ b/libshpool/src/attach.rs
@@ -113,7 +113,7 @@ fn do_attach(
         Ok(s) => s,
         Err(e) => {
             warn!("stdin is not a tty, using default size (err: {:?})", e);
-            tty::Size { rows: 24, cols: 80 }
+            tty::Size { rows: 24, cols: 80, xpixel: 0, ypixel: 0 }
         }
     };
 

--- a/libshpool/src/daemon/mod.rs
+++ b/libshpool/src/daemon/mod.rs
@@ -55,6 +55,7 @@ pub fn run(
             (Some(socket.clone()), UnixListener::bind(&socket).context("binding to socket")?)
         }
     };
+    info!("daemon::run 4");
     // spawn the signal handler thread in the background
     signals::Handler::new(cleanup_socket.clone()).spawn()?;
 

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -261,6 +261,8 @@ impl SessionInner {
                                 let oversize = tty::Size {
                                     rows: conn.size.rows + 1,
                                     cols: conn.size.cols + 1,
+                                    xpixel: conn.size.xpixel,
+                                    ypixel: conn.size.ypixel,
                                 };
                                 oversize.set_fd(pty_master.raw_fd().ok_or(anyhow!("no master fd"))?)?;
 

--- a/libshpool/src/daemon/show_motd.rs
+++ b/libshpool/src/daemon/show_motd.rs
@@ -39,8 +39,7 @@ impl DailyMessenger {
     /// Make a new Shower.
     pub fn new(mode: config::MotdDisplayMode, args: Option<Vec<String>>) -> anyhow::Result<Self> {
         Ok(DailyMessenger {
-            motd_resolver: motd::Resolver::new(motd::PamMotdResolutionStrategy::Auto)
-                .context("creating motd resolver")?,
+            motd_resolver: motd::Resolver::new().context("creating motd resolver")?,
             mode,
             args,
         })

--- a/shpool/Cargo.toml
+++ b/shpool/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.74"
 clap = { version = "4", features = ["derive"] } # cli parsing
 anyhow = "1" # dynamic, unstructured errors
 libshpool = { version = "0.6.0", path = "../libshpool" }
-motd = "0.2.0" # getting the message-of-the-day
 
 [dev-dependencies]
 lazy_static = "1" # globals

--- a/shpool/src/main.rs
+++ b/shpool/src/main.rs
@@ -20,8 +20,6 @@ use clap::Parser;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> anyhow::Result<()> {
-    motd::handle_reexec();
-
     let args = libshpool::Args::parse();
 
     if args.version() {


### PR DESCRIPTION
This patch fixes an issue where shpool would not forward the x and y pixel values from the term size struct. These fields are not consistently set by terminal emulators, but some of them do set them correctly and some client programs rely on them. We should do our part by shuttling them along.

I switched to using the pure-rust version of motd to avoid an issue with slow startup times that was causing test timing issues. This also makes the open source shpool work the same way as our google internal version and means that we have a smaller unsafe footprint, which is probably good.

I spent some effort trying to write a test for this, but could not get wrapping the `shpool attach` subprocess in a pty to work for whatever reason. I don't think it is worth the effort.

Fixes #13