### PR TITLE
add timeouts to session_message sends

### DIFF
--- a/libshpool/src/daemon/pager.rs
+++ b/libshpool/src/daemon/pager.rs
@@ -183,6 +183,7 @@ impl Pager {
             // since pagers don't stick around when the client hangs up
             // it is not really that importaint. Let's KISS.
             while let Ok(size) = tty_size_change_rx.recv() {
+                info!("recvd new size: {:?}", size);
                 if let Err(e) = size.set_fd(pty_master_fd) {
                     warn!("setting pager size: {:?}", e);
                 }

--- a/shpool/tests/kill.rs
+++ b/shpool/tests/kill.rs
@@ -143,7 +143,7 @@ fn reattach_after_kill() -> anyhow::Result<()> {
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
         let mut lm2 = sess2.line_matcher()?;
         sess2.run_cmd("echo ${MYVAR:-second}")?;
-        lm2.scan_until_re("second$")?;
+        lm2.scan_until_re(".*second.*")?;
 
         Ok(())
     })


### PR DESCRIPTION
Issue #17 describes a problem where we seem to
occasionally deadlock when the session message
handler holds the session message lock open for
a while. This patch adds some additional logging
and also adds some timeouts to the sends. The logging should help get to the root cause if it comes up
again and the timeouts on the sends should make
it so the daemon does not get completely wedged
when this happens.