### PR TITLE
clean up dangling print

### DIFF
--- a/libshpool/src/daemon/mod.rs
+++ b/libshpool/src/daemon/mod.rs
@@ -55,7 +55,6 @@ pub fn run(
             (Some(socket.clone()), UnixListener::bind(&socket).context("binding to socket")?)
         }
     };
-    info!("daemon::run 4");
     // spawn the signal handler thread in the background
     signals::Handler::new(cleanup_socket.clone()).spawn()?;
 


### PR DESCRIPTION
I noticed this when importing to the
google monorepo. I must have left it
in after debugging. Whoops.