### PR TITLE
fix bash prompt prefix injection script

### DIFF
--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -42,7 +42,10 @@ pub fn inject_prefix(
                SHPOOL__OLD_PS1="${{PS1}}"
                function __shpool__prompt_command() {{
                   PS1="${{SHPOOL__OLD_PS1}}"
-                  ${{SHPOOL__OLD_PROMPT_COMMAND}}
+                  for prompt_hook in ${{SHPOOL__OLD_PROMPT_COMMAND}}
+                  do
+                    ${{prompt_hook}}
+                  done
                   PS1="{prompt_prefix}${{PS1}}"
                }}
                PROMPT_COMMAND=__shpool__prompt_command


### PR DESCRIPTION
This patch fixes an issue with the bash prompt prefix injection script. It turns out PROMPT_COMMAND is actually a list of functions to invoke rather than a single function. This brings the bash implementation more in line with the zsh and fish implementations and makes it work correctly with multi-function prompt hooks.