### PR TITLE
sniff shells for prompt injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +184,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -295,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,10 +465,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9ea4b75e1a81675429dafe43441df1caea70081e82246a8cccf514884a88bb"
+dependencies = [
+ "bindgen",
+ "errno 0.3.8",
+ "libc",
+]
 
 [[package]]
 name = "libshpool"
@@ -427,6 +509,7 @@ dependencies = [
  "crossbeam-channel",
  "lazy_static",
  "libc",
+ "libproc",
  "log",
  "motd",
  "nix 0.28.0",
@@ -483,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +619,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -677,6 +776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +863,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shpool"

--- a/deny.toml
+++ b/deny.toml
@@ -16,5 +16,6 @@ allow = [
     "Apache-2.0",
     "MIT",
     "Unicode-DFS-2016",
+    "BSD-3-Clause", # notice
 ]
 confidence-threshold = 1.0

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -41,6 +41,7 @@ termini = "1.0.0" # terminfo database
 tempfile = "3" # RAII tmp files
 strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display
 notify = "6" # watch config file for updates
+libproc = "0.14.8" # sniffing shells by examining the subprocess
 
 # rusty wrapper for unix apis
 [dependencies.nix]

--- a/libshpool/src/consts.rs
+++ b/libshpool/src/consts.rs
@@ -24,5 +24,17 @@ pub const HEARTBEAT_DURATION: time::Duration = time::Duration::from_millis(500);
 pub const STDIN_FD: i32 = 0;
 pub const STDERR_FD: i32 = 2;
 
+// Used to determine when the shell has started up so we can attempt to sniff
+// what type of shell it is based on /proc/<pid>/exe.
+pub const STARTUP_SENTINEL: &str = "SHPOOL_STARTUP_SENTINEL";
+
+// Used to flag when prompt setup is complete and we can stop
+// dropping the output.
 pub const PROMPT_SENTINEL: &str = "SHPOOL_PROMPT_SETUP_SENTINEL";
-pub const PROMPT_SENTINEL_FLAG_VAR: &str = "SHPOOL__PRINT_PROMPT_SETUP_SENTINEL";
+
+// A magic env var which indicates that a `shpool daemon` invocation should
+// actually just print the given sentinal then exit. We do this because
+// using `echo` will cause the sentinal value to appear multiple times
+// in the output stream. For the same reason, we don't set the value
+// to an actual sentianl, but instead either "startup" or "prompt".
+pub const SENTINEL_FLAG_VAR: &str = "SHPOOL__INTERNAL__PRINT_SENTINEL";

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -195,7 +195,7 @@ impl SessionInner {
         use nix::poll;
 
         let term_db = Arc::clone(&self.term_db);
-        let mut prompt_sentinel_scanner = prompt::SentinelScanner::new();
+        let mut prompt_sentinel_scanner = prompt::SentinelScanner::new(consts::PROMPT_SENTINEL);
 
         // We only scan for the prompt sentinel if the user has not set up a
         // custom command.

--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -169,12 +169,16 @@ impl Args {
 /// Run the shpool tool with the given arguments. If hooks is provided,
 /// inject the callbacks into the daemon.
 pub fn run(args: Args, hooks: Option<Box<dyn hooks::Hooks + Send + Sync>>) -> anyhow::Result<()> {
-    if matches!(
-        (&args.command, env::var(consts::PROMPT_SENTINEL_FLAG_VAR).as_deref()),
-        (Commands::Daemon, Ok("yes"))
-    ) {
-        println!("{}", consts::PROMPT_SENTINEL);
-        std::process::exit(0);
+    match (&args.command, env::var(consts::SENTINEL_FLAG_VAR).as_deref()) {
+        (Commands::Daemon, Ok("prompt")) => {
+            println!("{}", consts::PROMPT_SENTINEL);
+            std::process::exit(0);
+        }
+        (Commands::Daemon, Ok("startup")) => {
+            println!("{}", consts::STARTUP_SENTINEL);
+            std::process::exit(0);
+        }
+        _ => {}
     }
 
     let trace_level = if args.verbose == 0 {

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1098,7 +1098,6 @@ fn prompt_prefix_zsh() -> anyhow::Result<()> {
 // change or something.
 #[test]
 #[timeout(30000)]
-#[ignore]
 fn prompt_prefix_fish() -> anyhow::Result<()> {
     support::dump_err(|| {
         let daemon_proc =

--- a/shpool/tests/daemon.rs
+++ b/shpool/tests/daemon.rs
@@ -291,7 +291,7 @@ fn echo_sentinel() -> anyhow::Result<()> {
         let output = Command::new(support::shpool_bin()?)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .env("SHPOOL__PRINT_PROMPT_SETUP_SENTINEL", "yes")
+            .env("SHPOOL__INTERNAL__PRINT_SENTINEL", "prompt")
             .arg("daemon")
             .output()?;
 


### PR DESCRIPTION

This patch teaches shpool to discern the shell it is launching
more accurately than we were doing in the past. Previously
we would just look at the name of the shell binary, but it
turns out this does not work well when people put `exec fish`
in their .bashrc or something similar. There are actually
some good reasons for people to do this rather than use chsh
or equivalent, so we should handle this usecase.

I tried a few different approaches to this before settling
on injecting a startup sentinal to the real shell, then
scanning for it and sniffing based off the pid once the
shell is fully started up. This ought to give the rc
files enough time to get processed, and it allows
us to avoid depending on an external binary like `ps`.

One drawback is that this won't work on non-linux,
so we will need to figure out an alternative to
/proc/<pid>/exe for the mac port.

One might think that passing `--version` would work,
but this won't handle execs in .rc files.

I tested this manually and the existing per-shell prompt
prefix tests already cover it.