### PR TITLE
re-enable fish test

### DIFF
--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -99,6 +99,8 @@ pub fn inject_prefix(
         format!("\n{}=yes /proc/{}/exe daemon\n", PROMPT_SENTINEL_FLAG_VAR, std::process::id());
     script.push_str(sentinel_cmd.as_str());
 
+    debug!("injecting prefix script '{}'", script);
+
     let mut pty_master = pty_master.is_parent().context("expected parent")?;
     pty_master.write_all(script.as_bytes()).context("running prefix script")?;
 

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1098,7 +1098,6 @@ fn prompt_prefix_zsh() -> anyhow::Result<()> {
 // change or something.
 #[test]
 #[timeout(30000)]
-#[ignore]
 fn prompt_prefix_fish() -> anyhow::Result<()> {
     support::dump_err(|| {
         let daemon_proc =
@@ -1122,6 +1121,7 @@ fn prompt_prefix_fish() -> anyhow::Result<()> {
         // initial prompt after half a second.
         std::thread::sleep(time::Duration::from_millis(500));
         child.kill().context("killing child")?;
+
 
         let mut stderr = child.stderr.take().context("missing stderr")?;
         let mut stderr_str = String::from("");


### PR DESCRIPTION
I had to disable this because it got broken in
the CI environment for some reason. This re-enables it.