### PR TITLE
link to wiki from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ an ssh proxy is holding the connection open in the vain hope that
 it will get some traffic again. You can just run `shpool detach main`
 to force the session to detach and allow you to attach.
 
+This README covers basic usage, but you can also check out
+[the wiki](https://github.com/shell-pool/shpool/wiki) for
+more tips and tricks.
+
 ### [Configuration](./CONFIG.md)
 
 You can customize some of `shpool`s behavior by editing your


### PR DESCRIPTION
This patch adds a link to the wiki from the README so that people will be able to find it. Shpool is (hopefully) a tool that will be able to fit into different people's workflows in lots of different ways, and the wiki will be a good place for folks to share their tricks. We already have one such tip in there.

Closes #49