### PR TITLE
bump motd to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "motd"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7d3038c0381e2d91295f07a042809979755365c3ae4decef81936f8ba49408"
+checksum = "2bb26d8886ea6ef1f7d8020dc7a74a48e0acff3ca49381f4aaea745ef7d2782c"
 dependencies = [
  "log",
  "serde",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -36,7 +36,7 @@ tracing = "0.1" # logging and performance monitoring facade
 bincode = "1" # serialization for the control protocol
 shpool_vt100 = "0.1.2" # terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
-motd = { version = "0.2.1", default-features = false, features = [] } # getting the message-of-the-day
+motd = { version = "0.2.2", default-features = false, features = [] } # getting the message-of-the-day
 termini = "1.0.0" # terminfo database
 tempfile = "3" # RAII tmp files
 strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display


### PR DESCRIPTION
This will make it so we no longer require libpam
to build.

Fixes #42