### PR TITLE
ban whitespace in session names

### DIFF
--- a/libshpool/src/attach.rs
+++ b/libshpool/src/attach.rs
@@ -40,6 +40,10 @@ pub fn run(
         eprintln!("blank session names are not allowed");
         return Ok(());
     }
+    if name.contains(char::is_whitespace) {
+        eprintln!("whitespace is not allowed in session names");
+        return Ok(());
+    }
 
     SignalHandler::new(name.clone(), socket.clone()).spawn()?;
 

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -492,6 +492,25 @@ fn blank_session_not_allowed() -> anyhow::Result<()> {
 
 #[test]
 #[timeout(30000)]
+fn whitespace_session_not_allowed() -> anyhow::Result<()> {
+    support::dump_err(|| {
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+        )
+        .context("starting daemon proc")?;
+
+        let mut tty1 =
+            daemon_proc.attach("this\tbad", Default::default()).context("attaching from tty1")?;
+        let mut line_matcher1 = tty1.stderr_line_matcher()?;
+        line_matcher1.scan_until_re("whitespace is not allowed in session names")?;
+
+        Ok(())
+    })
+}
+
+#[test]
+#[timeout(30000)]
 fn daemon_hangup() -> anyhow::Result<()> {
     support::dump_err(|| {
         let mut daemon_proc = support::daemon::Proc::new(


### PR DESCRIPTION
Whitespace in session names mangles list output
and is just generally confusing. I don't see a reason for it (though if someone has a usecase, this decision can be rolled back, we can solve the list issue with quoting or a json format or something).

Fixes #60