### PR TITLE
avoid prompt setup code when prompt_prefix = ""

### DIFF
--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -738,7 +738,7 @@ impl Server {
                 .prompt_prefix
                 .clone()
                 .unwrap_or(String::from(DEFAULT_PROMPT_PREFIX));
-            if let Err(err) = prompt::inject_prefix(&mut fork, &prompt_prefix, &header.name) {
+            if let Err(err) = prompt::maybe_inject_prefix(&mut fork, &prompt_prefix, &header.name) {
                 warn!("issue injecting prefix: {:?}", err);
             }
         }

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -198,8 +198,10 @@ impl SessionInner {
         let mut prompt_sentinel_scanner = prompt::SentinelScanner::new(consts::PROMPT_SENTINEL);
 
         // We only scan for the prompt sentinel if the user has not set up a
-        // custom command.
-        let mut has_seen_prompt_sentinel = self.custom_cmd;
+        // custom command or blanked out the prompt_prefix config option.
+        let prompt_prefix_is_blank =
+            self.config.get().prompt_prefix.as_ref().map(|p| p.is_empty()).unwrap_or(false);
+        let mut has_seen_prompt_sentinel = self.custom_cmd || prompt_prefix_is_blank;
 
         let daily_messenger = Arc::clone(&self.daily_messenger);
         let mut needs_initial_motd_dump = self.needs_initial_motd_dump;


### PR DESCRIPTION
This patch makes shpool truely do nothing when the user has blanked out their prompt prefix. Previously, we were just not running any shell setup code, but we were still emitting sentinals. This is bad because it means
that users who have written interactive code in their startup files cannot use shpool at all.

Fixes #64