### PR TITLE
ci: add automated release and publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "cargo"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,0 +1,66 @@
+name: Build Binaries # Continuous Deployment
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'shell-pool' && startsWith(github.event.release.name, 'shpool')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+          #- target: aarch64-apple-darwin
+          #  os: macos-12
+          #- target: x86_64-apple-darwin
+          #  os: macos-12
+          #- target: x86_64-unknown-freebsd
+          #  os: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Rust toolchain
+        uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
+        with:
+          inherit-toolchain: true
+          bins: cross
+      - uses: taiki-e/setup-cross-toolchain-action@241e9bf5f01f63286a020946ddaa3fd6d9c32cca
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+      - uses: taiki-e/upload-rust-binary-action@b988355f8b505d51359af5c8d4afc3646c3fac1e
+        with:
+          bin: shpool
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+      - uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
-          channel: '1.74.0'
+          inherit-toolchain: true
           bins: cargo-deny
       - run: sudo apt-get install libpam0g-dev
       - run: cargo deny --all-features check

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+      - uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
-          channel: '1.74.0'
+          inherit-toolchain: true
       - run: sudo apt-get install zsh fish libpam0g-dev
       - run: SHPOOL_LEAVE_TEST_LOGS=true cargo test --all-features
       - name: Archive Logs
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+      - uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
           components: rustfmt
           channel: nightly
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+      - uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
           components: clippy
           bins: cargo-cranky@0.3.0
@@ -64,9 +64,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+      - name: Install Rust toolchain
+        uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
-          channel: '1.74.0'
+          inherit-toolchain: true
           bins: cargo-deny
       - run: sudo apt-get install libpam0g-dev
       - run: cargo deny --all-features check licenses

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      # Generating a GitHub token, so that PRs and tags created by
+      # the release-plz-action can trigger actions workflows.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }} # <-- GitHub App ID secret name
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }} # <-- GitHub App private key secret name
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
+        with:
+          inherit-toolchain: true
+          bins: cross
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@86afd21a7b114234aab55ba0005eed52f77d89e4
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/HACKING.md
+++ b/HACKING.md
@@ -57,6 +57,19 @@ $ systemctl --user start shpool
 Run `cargo +nightly fmt` to ensure that the code matches the expected
 style.
 
+## Commit message style
+
+https://www.conventionalcommits.org/ is used to facilitate changelog generation.
+
+## Release
+
+[release-plz](https://release-plz.ieni.dev/) is used to manage the release
+process. It will create a release PR and keep it updated with any commits to
+the `master` branch. When the PR is merged, `release-plz` creates the tag and
+the release on GitHub and publishes the creates to creates.io.
+
+See https://release-plz.ieni.dev/ for more details.
+
 ## Measuring Latency
 
 To check e2e latency, you can use the

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,28 @@
+[workspace]
+# disable the changelog for all packages, will only enable for shpool
+changelog_update = false
+
+[changelog]
+header = ""
+body = """
+{{ package }} ({{ version | trim_start_matches(pat="v") }}) unstable; urgency=low
+{% for group, commits in commits | group_by(attribute="group") %}
+  {{ group | upper_first }}
+{% for commit in commits -%}
+{%- if commit.scope %}
+  * *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+{%- else %}
+  * {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{%- endif %}
+{%- endfor %}
+{% endfor %}
+ -- Shpool Authors <shpool-eng@google.com>  {{ now() | date(format="%a, %d %b %Y %T %z") }}
+"""
+trim = false
+
+[[package]]
+name = "shpool"
+changelog_update = true
+changelog_path = "./debian/changelog"
+# Also include changes in files in libshpool
+changelog_include = ["libshpool"]


### PR DESCRIPTION
* Enable release-plz to create release PRs automatically
* Enable automatic binary builds on Linux
* Enable version updates for rust and github actions using dependabot

Required repo secrets are

* `RELEASE_PLZ_APP_ID` and `RELEASE_PLZ_APP_PRIVATE_KEY` for the GitHub App. (See https://release-plz.ieni.dev/docs/github/token#use-a-github-app for setup)
* `CARGO_REGISTRY_TOKEN` for publishing to crates.io

GitHub repo further needs to be configured to allow GitHub actions to create and approve pull requets. See
https://release-plz.ieni.dev/docs/github/quickstart#1-change-github-actions-permissions

---

@ethanpailes we also need you to change the above repo settings and setup the workflow since I don't have admin access to the repo.

I've tested the release-plz to make sure its changelog generation still confirms to the debian changelog format. But I'll probably needs a few more iteration to tweak the workflows, since it's never possible to get them right on the first try...

Note that with this, we'll need to be a bit more disciplined with our commit messages to follow https://www.conventionalcommits.org/, otherwise the generated changelog would need to be tweaked everytime. One way to do this is to pay attention to the commit message when merging the PR with squash. This way, we can enforce a properly formatted commit message while still allow relatively effortless commits within the PR.

Fixes #53.