### PR TITLE
fix: tune vt100 memory usage

### DIFF
--- a/libshpool/src/config.rs
+++ b/libshpool/src/config.rs
@@ -206,6 +206,15 @@ pub struct Config {
     /// By default, 10000 lines.
     pub output_spool_lines: Option<usize>,
 
+    /// The width to use when storing session restoration lines via
+    /// the vt100 in-memory terminal engine (for the moment, the only
+    /// supported engine). vt100 allocates memory for the full width
+    /// for each line, leading to a lot of memory overhead, so playing
+    /// with this setting can be useful for tuning shpool's memory
+    /// usage. Eventually, this option will be deprecated once
+    /// the vt100 engine has been replaced.
+    pub vt100_output_spool_width: Option<u16>,
+
     /// The user supplied keybindings.
     pub keybinding: Option<Vec<Keybinding>>,
 
@@ -237,12 +246,12 @@ pub struct Config {
 }
 
 impl Config {
-    // Merge with `another` Config instance, with `self` taking higher priority,
-    // i.e. it is not communicative.
-    //
-    // Top level options with simple value are directly taken from `self`.
-    // List or map fields may be handled differently. If so, it will be highlighted
-    // in that field's documentation.
+    /// Merge with `another` Config instance, with `self` taking higher
+    /// priority, i.e. it is not commutative.
+    ///
+    /// Top level options with simple value are directly taken from `self`.
+    /// List or map fields may be handled differently. If so, it will be
+    /// highlighted in that field's documentation.
     pub fn merge(self, another: Config) -> Config {
         Config {
             norc: self.norc.or(another.norc),
@@ -257,6 +266,9 @@ impl Config {
             initial_path: self.initial_path.or(another.initial_path),
             session_restore_mode: self.session_restore_mode.or(another.session_restore_mode),
             output_spool_lines: self.output_spool_lines.or(another.output_spool_lines),
+            vt100_output_spool_width: self
+                .vt100_output_spool_width
+                .or(another.vt100_output_spool_width),
             keybinding: self.keybinding.or(another.keybinding),
             prompt_prefix: self.prompt_prefix.or(another.prompt_prefix),
             motd: self.motd.or(another.motd),

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -40,7 +40,7 @@ use crate::{
 // to use u16::MAX, since the vt100 crate eagerly fills in its rows, and doing
 // so is very memory intensive. The right fix is to get the vt100 crate to
 // lazily initialize its rows, but that is likely a bunch of work.
-const VTERM_WIDTH: u16 = 1024 * 10;
+const VTERM_WIDTH: u16 = 1024;
 
 const SHELL_KILL_TIMEOUT: time::Duration = time::Duration::from_millis(500);
 
@@ -206,6 +206,10 @@ impl SessionInner {
         let daily_messenger = Arc::clone(&self.daily_messenger);
         let mut needs_initial_motd_dump = self.needs_initial_motd_dump;
 
+        let vterm_width = {
+            let config = self.config.get();
+            config.vt100_output_spool_width.unwrap_or(VTERM_WIDTH)
+        };
         let mut pty_master = self.pty_master.is_parent()?;
         let watchable_master = pty_master;
         let name = self.name.clone();
@@ -218,7 +222,7 @@ impl SessionInner {
                 } else {
                     Some(shpool_vt100::Parser::new(
                         args.tty_size.rows,
-                        VTERM_WIDTH,
+                        vterm_width,
                         args.scrollback_lines,
                     ))
                 };


### PR DESCRIPTION
This patch tunes the default width for our in-memory terminal used for session restoration and adds a user controllable knob. This is a short term bandaid for #72, but doesn't really address the core issue.