### PR TITLE
ci: log rustc version in github workflows

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           inherit-toolchain: true
           bins: cross
+      - run: rustc --version
       - uses: taiki-e/setup-cross-toolchain-action@241e9bf5f01f63286a020946ddaa3fd6d9c32cca
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           inherit-toolchain: true
           bins: cargo-deny
+      - run: rustc --version
       - run: sudo apt-get install libpam0g-dev
       - run: cargo deny --all-features check
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5
         with:
           inherit-toolchain: true
+      - run: rustc --version
       - run: sudo apt-get install zsh fish libpam0g-dev
       - run: SHPOOL_LEAVE_TEST_LOGS=true cargo test --all-features
       - name: Archive Logs
@@ -43,6 +44,7 @@ jobs:
         with:
           components: rustfmt
           channel: nightly
+      - run: rustc --version
       - run: sudo apt-get install libpam0g-dev
       - run: cargo +nightly fmt -- --check
 
@@ -56,6 +58,7 @@ jobs:
           components: clippy
           bins: cargo-cranky@0.3.0
           channel: nightly
+      - run: rustc --version
       - run: sudo apt-get install zsh fish libpam0g-dev
       - run: cargo +nightly cranky --all-targets -- -D warnings
 
@@ -69,5 +72,6 @@ jobs:
         with:
           inherit-toolchain: true
           bins: cargo-deny
+      - run: rustc --version
       - run: sudo apt-get install libpam0g-dev
       - run: cargo deny --all-features check licenses

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           inherit-toolchain: true
           bins: cross
+      - run: rustc --versoin
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@86afd21a7b114234aab55ba0005eed52f77d89e4
         env:


### PR DESCRIPTION
I want to be able to confirm that the rust-toolchain.toml is getting correctly picked up by CI. It is importaint that we are using a pinned rustc version rather than the latest stable or nightly to make usre our
MSRV doesn't slip.