### PR TITLE
fix: protocol forward compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,15 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,7 +542,6 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_matches",
- "bincode",
  "byteorder",
  "chrono",
  "clap",
@@ -565,6 +555,7 @@ dependencies = [
  "nix 0.28.0",
  "notify",
  "ntest",
+ "rmp-serde",
  "serde",
  "serde_derive",
  "shell-words",
@@ -755,6 +746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +838,28 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5" # channels
 libc = "0.2" # basic libc types
 log = "0.4" # logging facade (not used directly, but required if we have tracing-log enabled)
 tracing = "0.1" # logging and performance monitoring facade
-bincode = "1" # serialization for the control protocol
+rmp-serde = "1" # serialization for the control protocol
 shpool_vt100 = "0.1.2" # terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
 motd = { version = "0.2.2", default-features = false, features = [] } # getting the message-of-the-day

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -916,7 +916,7 @@ impl Server {
 #[instrument(skip_all)]
 fn parse_connect_header(stream: &mut UnixStream) -> anyhow::Result<protocol::ConnectHeader> {
     let header: protocol::ConnectHeader =
-        bincode::deserialize_from(stream).context("parsing header")?;
+        protocol::decode_from(stream).context("parsing header")?;
     Ok(header)
 }
 
@@ -930,7 +930,7 @@ where
         .context("setting write timout on inbound session")?;
 
     let serializeable_stream = stream.try_clone().context("cloning stream handle")?;
-    bincode::serialize_into(serializeable_stream, &header).context("writing reply")?;
+    protocol::encode_to(&header, serializeable_stream).context("writing reply")?;
 
     stream.set_write_timeout(None).context("unsetting write timout on inbound session")?;
     Ok(())


### PR DESCRIPTION
This patch switches us from using bincode, which has pretty terrible forwards compatibility properties
to using msgpack (I think I did a switch in the
previous direction in the past). bincode is faster, but we don't actually care about encoding speed
since we are just encoding some tiny baby little
headers at the start of a connection. This
change also adds a bunch of #[serde(default)]
annotations, which should take care of the second
half of forwards compatibilty.

This means one last protocol version break before
hopefully being able to evolve the protocol in a
much more civilized manner.

I realized I was going to have to add a protocol
field for #47, so this should be done first.

Fixes #85