### PR TITLE
feat: add autodaemonization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +555,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-channel",
+ "daemonize",
  "directories",
  "lazy_static",
  "libc",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ that `shpool` does not break native scrollback or copy-paste.
 
 ### Installing from crates.io
 
+#### Using systemd to run the daemon
+
 Run
 
 ```
@@ -23,6 +25,21 @@ systemctl --user enable shpool
 systemctl --user start shpool
 loginctl enable-linger
 ```
+
+#### Without systemd
+
+To install without setting up systemd, run
+
+```
+cargo install shpool
+```
+
+If you don't use systemd, you can either port the `systemd/shpool.service`
+file to your own init system and use that, or you can use autodaemonization
+mode to tell shpool to just fork a daemon process on the fly if it notices
+one is not missing. Autodaemonization is enabled by default, so you don't
+need to do anything special to use it, though you can control its behavior
+with the `nodaemonize` config option and the `-d/-D` command line switches.
 
 ## Usage
 

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -43,6 +43,7 @@ strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display
 notify = "6" # watch config file for updates
 libproc = "0.14.8" # sniffing shells by examining the subprocess
 directories = "5.0.1" # get paths for configurations
+daemonize = "0.5" # autodaemonization
 
 # rusty wrapper for unix apis
 [dependencies.nix]

--- a/libshpool/src/attach.rs
+++ b/libshpool/src/attach.rs
@@ -26,7 +26,7 @@ use super::{
 const MAX_FORCE_RETRIES: usize = 20;
 
 pub fn run(
-    config_file: Option<String>,
+    config_manager: config::Manager,
     name: String,
     force: bool,
     ttl: Option<String>,
@@ -46,8 +46,6 @@ pub fn run(
     }
 
     SignalHandler::new(name.clone(), socket.clone()).spawn()?;
-
-    let config_manager = config::Manager::new(config_file.as_deref())?;
 
     let ttl = match &ttl {
         Some(src) => match duration::parse(src.as_str()) {

--- a/libshpool/src/config.rs
+++ b/libshpool/src/config.rs
@@ -117,6 +117,7 @@ impl Manager {
         let mut config = Config::default();
         for path in config_files {
             let path = path.as_ref();
+            info!("loading config from {:?}", path);
             let config_str = match fs::read_to_string(path) {
                 Err(e) => {
                     warn!("skip reading config file {}: {:?}", path.display(), e);
@@ -177,6 +178,17 @@ pub struct Config {
     /// variables found there into new shells. If this flag is set,
     /// it will avoid doing so.
     pub noread_etc_environment: Option<bool>,
+
+    /// By default, shpool will check for a running daemon, and if
+    /// one is not found, automatically spawn a daemon in the background.
+    /// With this option set, it will not do this by default.
+    /// (though this value will be overridden by the -d/--daemonize
+    /// or -D/--no-daemonize flags).
+    pub nodaemonize: Option<bool>,
+
+    /// If set, autodamonization will not timeout when waiting for the
+    /// daemon to come up and will instead spin forever.
+    pub nodaemonize_timeout: Option<bool>,
 
     /// shell overrides the user's default shell
     pub shell: Option<String>,
@@ -260,6 +272,8 @@ impl Config {
                 .nosymlink_ssh_auth_sock
                 .or(another.nosymlink_ssh_auth_sock),
             noread_etc_environment: self.noread_etc_environment.or(another.noread_etc_environment),
+            nodaemonize: self.nodaemonize.or(another.nodaemonize),
+            nodaemonize_timeout: self.nodaemonize_timeout.or(another.nodaemonize_timeout),
             shell: self.shell.or(another.shell),
             env: self.env.or(another.env),
             forward_env: self.forward_env.or(another.forward_env),

--- a/libshpool/src/consts.rs
+++ b/libshpool/src/consts.rs
@@ -38,3 +38,6 @@ pub const PROMPT_SENTINEL: &str = "SHPOOL_PROMPT_SETUP_SENTINEL";
 // in the output stream. For the same reason, we don't set the value
 // to an actual sentianl, but instead either "startup" or "prompt".
 pub const SENTINEL_FLAG_VAR: &str = "SHPOOL__INTERNAL__PRINT_SENTINEL";
+
+// If set to "true", the daemon will autodaemonize after launch.
+pub const AUTODAEMONIZE_VAR: &str = "SHPOOL__INTERNAL__AUTODAEMONIZE";

--- a/libshpool/src/daemonize.rs
+++ b/libshpool/src/daemonize.rs
@@ -1,0 +1,95 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ffi::OsStr, os::unix::net::UnixStream, path::Path, process, thread, time::Duration};
+
+use crate::{config, consts, Args};
+
+use anyhow::{anyhow, Context};
+use tracing::info;
+
+/// Check if we can connect to the control socket, and if we
+/// can't, fork the daemon in the background.
+pub fn maybe_fork_daemon<B, P>(
+    config_manager: &config::Manager,
+    args: &Args,
+    shpool_bin: B,
+    control_sock: P,
+) -> anyhow::Result<()>
+where
+    B: AsRef<OsStr>,
+    P: AsRef<Path>,
+{
+    let control_sock = control_sock.as_ref();
+
+    if UnixStream::connect(control_sock).is_ok() {
+        info!("daemon already running on {:?}, no need to autodaemonize", control_sock);
+        // There is already a daemon listening on the control socket, we
+        // don't need to do anything.
+        return Ok(());
+    }
+    info!("no daemon running on {:?}, autodaemonizing", control_sock);
+
+    let log_file = control_sock.with_file_name("daemonized-shpool.log");
+
+    let mut cmd = process::Command::new(shpool_bin);
+    if let Some(config_file) = &args.config_file {
+        cmd.arg("--config-file").arg(config_file);
+    }
+    cmd.arg("--log-file")
+        .arg(log_file)
+        .arg("--socket")
+        .arg(control_sock.as_os_str())
+        .arg("daemon")
+        .env(consts::AUTODAEMONIZE_VAR, "true")
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .spawn()
+        .context("launching background daemon")?;
+    info!("launched background daemon");
+
+    // Now poll with exponential backoff until we can dial the control socket.
+    if config_manager.get().nodaemonize_timeout.unwrap_or(false) {
+        info!("waiting for daemon to come up with no timeout");
+        let mut sleep_ms = 10;
+        let max_sleep_ms = 2000;
+        loop {
+            if UnixStream::connect(control_sock).is_ok() {
+                info!("connected to freshly launched background daemon");
+                return Ok(());
+            }
+
+            thread::sleep(Duration::from_millis(sleep_ms));
+            sleep_ms *= 2;
+            if sleep_ms > max_sleep_ms {
+                sleep_ms = max_sleep_ms;
+            }
+        }
+    } else {
+        info!("waiting for daemon to come up with timeout");
+        // `sum(10*(2**x) for x in range(9))` = 5110 ms = ~5 s
+        let mut sleep_ms = 10;
+        for _ in 0..9 {
+            if UnixStream::connect(control_sock).is_ok() {
+                info!("connected to freshly launched background daemon");
+                return Ok(());
+            }
+
+            thread::sleep(Duration::from_millis(sleep_ms));
+            sleep_ms *= 2;
+        }
+    }
+
+    Err(anyhow!("daemonizing: launched daemon, but control socket never came up"))
+}

--- a/shpool/tests/detach.rs
+++ b/shpool/tests/detach.rs
@@ -68,6 +68,7 @@ fn no_daemon() -> anyhow::Result<()> {
         let out = Command::new(support::shpool_bin()?)
             .arg("--socket")
             .arg("/fake/does/not/exist/shpool.socket")
+            .arg("--no-daemonize")
             .arg("detach")
             .output()
             .context("spawning detach proc")?;

--- a/shpool/tests/kill.rs
+++ b/shpool/tests/kill.rs
@@ -14,6 +14,7 @@ fn no_daemon() -> anyhow::Result<()> {
         let out = Command::new(support::shpool_bin()?)
             .arg("--socket")
             .arg("/fake/does/not/exist/shpool.socket")
+            .arg("--no-daemonize")
             .arg("kill")
             .output()
             .context("spawning kill proc")?;

--- a/shpool/tests/list.rs
+++ b/shpool/tests/list.rs
@@ -38,6 +38,7 @@ fn no_daemon() -> anyhow::Result<()> {
         let out = Command::new(support::shpool_bin()?)
             .arg("--socket")
             .arg("/fake/does/not/exist/shpool.socket")
+            .arg("--no-daemonize")
             .arg("list")
             .output()
             .context("spawning list proc")?;

--- a/shpool/tests/support/daemon.rs
+++ b/shpool/tests/support/daemon.rs
@@ -205,6 +205,8 @@ impl Proc {
                     .into_string()
                     .map_err(|e| anyhow!("conversion error: {:?}", e))?,
             ),
+            daemonize: false,
+            no_daemonize: true,
             command: libshpool::Commands::Daemon,
         };
         let hooks_recorder = Box::new(HooksRecorder {
@@ -277,6 +279,7 @@ impl Proc {
             .arg(&log_file)
             .arg("--socket")
             .arg(&self.socket_path)
+            .arg("--no-daemonize")
             .env_clear()
             .env("SHPOOL_TEST_HOOK_SOCKET_PATH", &test_hook_socket_path)
             .envs(args.extra_env)


### PR DESCRIPTION
This patch teaches shpool to daemonize like
pretty much all the other tools in the space.
Shpool has been pretty weird in not supporting
this considering this is how tmux and whatnot
work.

This new behavior needs to be opted into via
a command line flag, but part of me thinks that
it ought to be the new default behavior. If there
is a systemd service up and running it will get
used and otherwise a background daemon will get
fallen back on. I am a little worried that
people could get in a weird state if their
systemd service stalls out and they daemonize
without realizing it, but maybe that is an
ok tradeoff in exchange for better reliability
and more "just working" behavior.

BREAKING CHANGE: new arg field breaks libshpool public interface

Fixes #56