### PR TITLE
fix: migrate to new shpool-protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "shell-words",
+ "shpool-protocol",
  "shpool_pty",
  "shpool_vt100",
  "signal-hook",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -44,6 +44,7 @@ notify = "6" # watch config file for updates
 libproc = "0.14.8" # sniffing shells by examining the subprocess
 directories = "5.0.1" # get paths for configurations
 daemonize = "0.5" # autodaemonization
+shpool-protocol = { version = "0.1.0", path = "../shpool-protocol" } # client-server protocol
 
 # rusty wrapper for unix apis
 [dependencies.nix]

--- a/libshpool/src/daemon/show_motd.rs
+++ b/libshpool/src/daemon/show_motd.rs
@@ -20,12 +20,14 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use shpool_protocol::{Chunk, ChunkKind, TtySize};
 use tracing::{info, instrument};
 
 use crate::{
     config,
     daemon::pager::{Pager, PagerCtl},
-    duration, protocol, tty,
+    duration,
+    protocol::ChunkExt as _,
 };
 
 /// Showers know how to show the message of the day.
@@ -65,8 +67,7 @@ impl DailyMessenger {
 
         let raw_motd_value = self.raw_motd_value(term_db)?;
 
-        let chunk =
-            protocol::Chunk { kind: protocol::ChunkKind::Data, buf: raw_motd_value.as_slice() };
+        let chunk = Chunk { kind: ChunkKind::Data, buf: raw_motd_value.as_slice() };
 
         chunk.write_to(&mut stream).context("dumping motd")
     }
@@ -88,8 +89,8 @@ impl DailyMessenger {
         // The session to associate this pager with for SIGWINCH purposes.
         ctl_slot: Arc<Mutex<Option<PagerCtl>>>,
         // The size of the tty to start off with
-        init_tty_size: tty::Size,
-    ) -> anyhow::Result<Option<tty::Size>> {
+        init_tty_size: TtySize,
+    ) -> anyhow::Result<Option<TtySize>> {
         if let Some(debouncer) = &self.debouncer {
             if !debouncer.should_fire()? {
                 return Ok(None);

--- a/libshpool/src/detach.rs
+++ b/libshpool/src/detach.rs
@@ -15,11 +15,9 @@
 use std::{io, path::Path};
 
 use anyhow::{anyhow, Context};
+use shpool_protocol::{ConnectHeader, DetachReply, DetachRequest};
 
-use super::{
-    common, protocol,
-    protocol::{ConnectHeader, DetachReply, DetachRequest},
-};
+use crate::{common, protocol};
 
 pub fn run<P>(mut sessions: Vec<String>, socket: P) -> anyhow::Result<()>
 where

--- a/libshpool/src/kill.rs
+++ b/libshpool/src/kill.rs
@@ -15,11 +15,9 @@
 use std::{io, path::Path};
 
 use anyhow::{anyhow, Context};
+use shpool_protocol::{ConnectHeader, KillReply, KillRequest};
 
-use super::{
-    common, protocol,
-    protocol::{ConnectHeader, KillReply, KillRequest},
-};
+use crate::{common, protocol};
 
 pub fn run<P>(mut sessions: Vec<String>, socket: P) -> anyhow::Result<()>
 where

--- a/libshpool/src/list.rs
+++ b/libshpool/src/list.rs
@@ -15,11 +15,9 @@
 use std::{io, path::PathBuf, time};
 
 use anyhow::Context;
+use shpool_protocol::{ConnectHeader, ListReply};
 
-use super::{
-    protocol,
-    protocol::{ConnectHeader, ListReply},
-};
+use crate::protocol;
 
 pub fn run(socket: PathBuf) -> anyhow::Result<()> {
     let mut client = match protocol::Client::new(socket) {

--- a/libshpool/src/protocol.rs
+++ b/libshpool/src/protocol.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use std::{
-    default::Default,
-    fmt,
     io::{self, Read, Write},
     os::unix::net::UnixStream,
     path::Path,
@@ -23,9 +21,9 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt as _, WriteBytesExt as _};
 use serde::{Deserialize, Serialize};
-use serde_derive::{Deserialize, Serialize};
+use shpool_protocol::{Chunk, ChunkKind, ConnectHeader};
 use tracing::{debug, error, instrument, span, trace, warn, Level};
 
 use super::{consts, tty};
@@ -63,290 +61,20 @@ where
     Ok(d)
 }
 
-/// ConnectHeader is the blob of metadata that a client transmits when it
-/// first connections. It uses an enum to allow different connection types
-/// to be initiated on the same socket. The ConnectHeader is always prefixed
-/// with a 4 byte little endian unsigned word to indicate length.
-#[derive(Serialize, Deserialize, Debug)]
-pub enum ConnectHeader {
-    /// Attach to the named session indicated by the given header.
-    ///
-    /// Responds with an AttachReplyHeader.
-    Attach(AttachHeader),
-    /// List all of the currently active sessions.
-    List,
-    /// A message for a named, running sessions. This
-    /// provides a mechanism for RPC-like calls to be
-    /// made to running sessions. Messages are only
-    /// delivered if there is currently a client attached
-    /// to the session because we need a servicing thread
-    /// with access to the SessionInner to respond to requests
-    /// (we could implement a mailbox system or something
-    /// for detached threads, but so far we have not needed to).
-    SessionMessage(SessionMessageRequest),
-    /// A message to request that a list of running
-    /// sessions get detached from.
-    Detach(DetachRequest),
-    /// A message to request that a list of running
-    /// sessions get killed.
-    Kill(KillRequest),
+/// Methods for the Chunk protocol struct. Protocol structs
+/// are always bare structs, so we use ext traits to mix in methods.
+pub trait ChunkExt<'data>: Sized {
+    fn write_to<W>(&self, w: &mut W) -> io::Result<()>
+    where
+        W: std::io::Write;
+
+    fn read_into<R>(r: &mut R, buf: &'data mut [u8]) -> anyhow::Result<Self>
+    where
+        R: std::io::Read;
 }
 
-/// KillRequest represents a request to kill
-/// the given named sessions.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct KillRequest {
-    /// The sessions to detach
-    #[serde(default)]
-    pub sessions: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct KillReply {
-    #[serde(default)]
-    pub not_found_sessions: Vec<String>,
-}
-
-/// DetachRequest represents a request to detach
-/// from the given named sessions.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct DetachRequest {
-    /// The sessions to detach
-    #[serde(default)]
-    pub sessions: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct DetachReply {
-    /// sessions that are not even in the session table
-    #[serde(default)]
-    pub not_found_sessions: Vec<String>,
-    /// sessions that are in the session table, but have no
-    /// tty attached
-    #[serde(default)]
-    pub not_attached_sessions: Vec<String>,
-}
-
-/// SessionMessageRequest represents a request that
-/// ought to be routed to the session indicated by
-/// `session_name`.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct SessionMessageRequest {
-    /// The session to route this request to.
-    #[serde(default)]
-    pub session_name: String,
-    /// The actual message to send to the session.
-    #[serde(default)]
-    pub payload: SessionMessageRequestPayload,
-}
-
-/// SessionMessageRequestPayload contains a request for
-/// a running session.
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub enum SessionMessageRequestPayload {
-    /// Resize a named session's pty. Generated when
-    /// a `shpool attach` process receives a SIGWINCH.
-    Resize(ResizeRequest),
-    /// Detach the given session. Generated internally
-    /// by the server from a batch detach request.
-    #[default]
-    Detach,
-}
-
-/// ResizeRequest resizes the pty for a given named session.
-/// We use an out-of-band request rather than doing this
-/// in the input stream because we don't want to have to
-/// introduce a framing protocol for the input stream.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ResizeRequest {
-    /// The size of the client's tty
-    #[serde(default)]
-    pub tty_size: tty::Size,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub enum SessionMessageReply {
-    /// The session was not found in the session table
-    NotFound,
-    /// There is not terminal attached to the session so
-    /// it can't handle messages right now.
-    NotAttached,
-    /// The response to a resize message
-    Resize(ResizeReply),
-    /// The response to a detach message
-    Detach(SessionMessageDetachReply),
-}
-
-/// A reply to a detach message
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub enum SessionMessageDetachReply {
-    Ok,
-}
-
-/// A reply to a resize message
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub enum ResizeReply {
-    Ok,
-}
-
-/// AttachHeader is the blob of metadata that a client transmits when it
-/// first dials into the shpool daemon indicating which shell it wants
-/// to attach to.
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct AttachHeader {
-    /// The name of the session to create or attach to.
-    #[serde(default)]
-    pub name: String,
-    /// The size of the local tty. Passed along so that the remote
-    /// pty can be kept in sync (important so curses applications look
-    /// right).
-    #[serde(default)]
-    pub local_tty_size: tty::Size,
-    /// A subset of the environment of the shell that `shpool attach` is run
-    /// in. Contains only some variables needed to set up the shell when
-    /// shpool forks off a process. For now the list is just `SSH_AUTH_SOCK`
-    /// and `TERM`.
-    #[serde(default)]
-    pub local_env: Vec<(String, String)>,
-    /// If specified, sets a time limit on how long the shell will be open
-    /// when the shell is first created (does nothing in the case of a
-    /// reattach). The daemon is responsible for automatically killing the
-    /// session once the ttl is over.
-    #[serde(default)]
-    pub ttl_secs: Option<u64>,
-    /// If specified, a command to run instead of the users default shell.
-    #[serde(default)]
-    pub cmd: Option<String>,
-}
-
-impl AttachHeader {
-    pub fn local_env_get(&self, var: &str) -> Option<&str> {
-        self.local_env.iter().find(|(k, _)| k == var).map(|(_, v)| v.as_str())
-    }
-}
-
-/// AttachReplyHeader is the blob of metadata that the shpool service prefixes
-/// the data stream with after an attach. In can be used to indicate a
-/// connection error.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct AttachReplyHeader {
-    #[serde(default)]
-    pub status: AttachStatus,
-}
-
-/// ListReply is contains a list of active sessions to be displayed to the user.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ListReply {
-    #[serde(default)]
-    pub sessions: Vec<Session>,
-}
-
-/// Session describes an active session.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Session {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub started_at_unix_ms: i64,
-    #[serde(default)]
-    pub status: SessionStatus,
-}
-
-/// Indicates if a shpool session currently has a client attached.
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub enum SessionStatus {
-    #[default]
-    Attached,
-    Disconnected,
-}
-
-impl fmt::Display for SessionStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SessionStatus::Attached => write!(f, "attached"),
-            SessionStatus::Disconnected => write!(f, "disconnected"),
-        }
-    }
-}
-
-/// AttachStatus indicates what happened during an attach attempt.
-#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
-pub enum AttachStatus {
-    /// Attached indicates that there was an existing shell session with
-    /// the given name, and `shpool attach` successfully connected to it.
-    ///
-    /// NOTE: warnings is not currently used, but it used to be, and we
-    /// might want it in the future, so it is not worth breaking the protocol
-    /// over.
-    Attached { warnings: Vec<String> },
-    /// Created indicates that there was no existing shell session with the
-    /// given name, so `shpool` created a new one.
-    ///
-    /// NOTE: warnings is not currently used, see above.
-    Created { warnings: Vec<String> },
-    /// Busy indicates that there is an existing shell session with the given
-    /// name, but another shpool session is currently connected to
-    /// it, so the connection attempt was rejected.
-    Busy,
-    /// Forbidden indicates that the daemon has rejected the connection
-    /// attempt for security reasons.
-    Forbidden(String),
-    /// Some unexpected error
-    UnexpectedError(String),
-}
-
-impl Default for AttachStatus {
-    fn default() -> Self {
-        AttachStatus::UnexpectedError(String::from("default"))
-    }
-}
-
-/// ChunkKind is a tag that indicates what type of frame is being transmitted
-/// through the socket.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ChunkKind {
-    /// After the kind tag, the chunk will have a 4 byte little endian length
-    /// prefix followed by the actual data.
-    Data = 0,
-    /// An empty chunk sent so that the daemon can check to make sure the attach
-    /// process is still listening.
-    Heartbeat = 1,
-    /// The child shell has exited. After the kind tag, the chunk will
-    /// have exactly 4 bytes of data, which will contain a little endian
-    /// code indicating the child's exit status.
-    ExitStatus = 2,
-}
-
-impl TryFrom<u8> for ChunkKind {
-    type Error = anyhow::Error;
-
-    fn try_from(v: u8) -> anyhow::Result<Self> {
-        match v {
-            0 => Ok(ChunkKind::Data),
-            1 => Ok(ChunkKind::Heartbeat),
-            2 => Ok(ChunkKind::ExitStatus),
-            _ => Err(anyhow!("unknown ChunkKind {}", v)),
-        }
-    }
-}
-
-/// Chunk represents of a chunk of data in the output stream
-///
-/// format:
-///
-/// ```text
-/// 1 byte: kind tag
-/// little endian 4 byte word: length prefix
-/// N bytes: data
-/// ```
-#[derive(Debug, PartialEq)]
-pub struct Chunk<'data> {
-    pub kind: ChunkKind,
-    pub buf: &'data [u8],
-}
-
-impl<'data> Chunk<'data> {
-    pub fn write_to<W>(&self, w: &mut W) -> io::Result<()>
+impl<'data> ChunkExt<'data> for Chunk<'data> {
+    fn write_to<W>(&self, w: &mut W) -> io::Result<()>
     where
         W: std::io::Write,
     {
@@ -363,7 +91,7 @@ impl<'data> Chunk<'data> {
         Ok(())
     }
 
-    pub fn read_into<R>(r: &mut R, buf: &'data mut [u8]) -> anyhow::Result<Self>
+    fn read_into<R>(r: &mut R, buf: &'data mut [u8]) -> anyhow::Result<Self>
     where
         R: std::io::Read,
     {

--- a/shpool/tests/daemon.rs
+++ b/shpool/tests/daemon.rs
@@ -4,7 +4,7 @@ use std::{
     os::unix::{
         io::{AsRawFd, FromRawFd},
         net::UnixListener,
-        process::CommandExt,
+        process::CommandExt as _,
     },
     path,
     process::{Command, Stdio},

--- a/shpool/tests/support/daemon.rs
+++ b/shpool/tests/support/daemon.rs
@@ -1,7 +1,7 @@
 use std::{
     default::Default,
     env,
-    os::unix::{net::UnixStream, prelude::ExitStatusExt},
+    os::unix::{net::UnixStream, prelude::ExitStatusExt as _},
     path::{Path, PathBuf},
     process,
     process::{Command, Stdio},


### PR DESCRIPTION
This patch migrates us from the old protocol
module to the new protocol crate. The logic
remains in the protocol module in the form
of the client struct and the new ChunkExt
extension trait since the methods don't
belong in the protocol description itself.

This does not yet add the version negotiation
logic that we will need before our next release,
but it does get us one step closer to resolving
issue #88.