### PR TITLE
fix: add version negotiation warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "shpool-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -43,7 +43,7 @@ strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display
 notify = "6" # watch config file for updates
 libproc = "0.14.8" # sniffing shells by examining the subprocess
 daemonize = "0.5" # autodaemonization
-shpool-protocol = { version = "0.1.0", path = "../shpool-protocol" } # client-server protocol
+shpool-protocol = { version = "0.2.0", path = "../shpool-protocol" } # client-server protocol
 
 # rusty wrapper for unix apis
 [dependencies.nix]

--- a/libshpool/src/kill.rs
+++ b/libshpool/src/kill.rs
@@ -17,14 +17,18 @@ use std::{io, path::Path};
 use anyhow::{anyhow, Context};
 use shpool_protocol::{ConnectHeader, KillReply, KillRequest};
 
-use crate::{common, protocol};
+use crate::{common, protocol, protocol::ClientResult};
 
 pub fn run<P>(mut sessions: Vec<String>, socket: P) -> anyhow::Result<()>
 where
     P: AsRef<Path>,
 {
     let mut client = match protocol::Client::new(socket) {
-        Ok(c) => c,
+        Ok(ClientResult::JustClient(c)) => c,
+        Ok(ClientResult::VersionMismatch { warning, client }) => {
+            eprintln!("warning: {}, try restarting your daemon", warning);
+            client
+        }
         Err(err) => {
             let io_err = err.downcast::<io::Error>()?;
             if io_err.kind() == io::ErrorKind::NotFound {

--- a/shpool-protocol/Cargo.toml
+++ b/shpool-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shpool-protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Ethan Pailes <pailes@google.com>"]
 repository = "https://github.com/shell-pool/shpool"

--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -19,7 +19,19 @@ use serde_derive::{Deserialize, Serialize};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// ConnectHeader is the blob of metadata that a client transmits when it
+/// The header used to advertize daemon version.
+///
+/// This header gets written by the daemon to every stream as
+/// soon as it is opened, which allows the client to compare
+/// version strings for protocol negotiation (basically just
+/// deciding if the user ought to be warned about mismatched
+/// versions).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct VersionHeader {
+    pub version: String,
+}
+
+/// The blob of metadata that a client transmits when it
 /// first connects.
 ///
 /// It uses an enum to allow different connection types

--- a/shpool/tests/kill.rs
+++ b/shpool/tests/kill.rs
@@ -53,6 +53,43 @@ fn empty() -> anyhow::Result<()> {
 
 #[test]
 #[timeout(30000)]
+fn version_mismatch_client_newer() -> anyhow::Result<()> {
+    support::dump_err(|| {
+        let mut daemon_proc = support::daemon::Proc::new(
+            "norc.toml",
+            DaemonArgs {
+                extra_env: vec![(
+                    String::from("SHPOOL_TEST__OVERRIDE_VERSION"),
+                    String::from("0.0.0"),
+                )],
+                ..DaemonArgs::default()
+            },
+        )
+        .context("starting daemon proc")?;
+
+        let waiter = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
+        let mut attach_proc =
+            daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
+
+        // get past the version mismatch prompt
+        attach_proc.run_cmd("")?;
+
+        daemon_proc.events = Some(waiter.wait_final_event("daemon-bidi-stream-enter")?);
+
+        let out = daemon_proc.kill(vec![String::from("sh1")])?;
+        assert!(out.status.success());
+
+        let stderr = String::from_utf8_lossy(&out.stderr[..]);
+        println!("stderr: {}", stderr);
+        assert!(stderr.contains("is newer"));
+        assert!(stderr.contains("try restarting"));
+
+        Ok(())
+    })
+}
+
+#[test]
+#[timeout(30000)]
 fn single_attached() -> anyhow::Result<()> {
     support::dump_err(|| {
         let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())


### PR DESCRIPTION
This patch adds some version negotiation logic
and appropriate warnings to shpool. Shpool remains permissive about version mismatches, only issuing
warnings so that the user may continue to perform
any operations which still function correctly, but it now provides recommendations on how to
address the issue.

The protocol version is determined by the new
shpool-protocol crate.

Fixes #88