### PR TITLE
fix: exit success for graceful detaches

### DIFF
--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -554,7 +554,8 @@ fn default_keybinding_detach() -> anyhow::Result<()> {
         lm1.scan_until_re("someval$")?;
 
         a1.run_raw_cmd(vec![0, 17])?; // Ctrl-Space Ctrl-q
-        a1.proc.wait()?;
+        let exit_status = a1.proc.wait()?;
+        assert!(exit_status.success());
 
         waiter.wait_event("daemon-bidi-stream-done")?;
 

--- a/shpool/tests/detach.rs
+++ b/shpool/tests/detach.rs
@@ -19,7 +19,7 @@ fn single_running() -> anyhow::Result<()> {
             .take()
             .unwrap()
             .waiter(["daemon-bidi-stream-enter", "daemon-bidi-stream-done"]);
-        let _attach_proc =
+        let mut attach_proc =
             daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
         waiter.wait_event("daemon-bidi-stream-enter")?;
 
@@ -33,6 +33,9 @@ fn single_running() -> anyhow::Result<()> {
         assert_eq!(stdout.len(), 0, "expected no stdout");
 
         daemon_proc.events = Some(waiter.wait_final_event("daemon-bidi-stream-done")?);
+
+        let attach_exit_status = attach_proc.proc.wait()?;
+        assert!(attach_exit_status.success());
 
         Ok(())
     })


### PR DESCRIPTION
This patch fixes the exit code for the attach
process so that it is 0 when shpool has been
told to gracefully detach, either via the
`shpool detach` subcommand or via the detach
keybinding. It is more semantically correct
to exit 0 in these cases.

Fixes #130

BREAKING CHANGE: technically could impact some scripts