### PR TITLE
fix: forward shell env to pager

### DIFF
--- a/libshpool/src/daemon/pager.rs
+++ b/libshpool/src/daemon/pager.rs
@@ -104,6 +104,8 @@ impl Pager {
         init_tty_size: TtySize,
         // The message to display
         msg: &str,
+        // The env to launch the pager proc with
+        shell_env: &[(String, String)],
     ) -> anyhow::Result<TtySize> {
         let (tty_size_change_tx, tty_size_change_rx) = crossbeam_channel::bounded(0);
         let (tty_size_change_ack_tx, tty_size_change_ack_rx) = crossbeam_channel::bounded(0);
@@ -128,6 +130,7 @@ impl Pager {
         msg_file.write_all(cleaned_msg.as_slice()).context("writing msg to tmp pager file")?;
 
         let mut cmd = process::Command::new(&self.pager_bin);
+        cmd.env_clear().envs(shell_env.to_vec());
         cmd.arg(msg_file.path().as_os_str());
 
         // fork, leaving us with a handle in the master branch

--- a/libshpool/src/daemon/show_motd.rs
+++ b/libshpool/src/daemon/show_motd.rs
@@ -90,6 +90,10 @@ impl DailyMessenger {
         ctl_slot: Arc<Mutex<Option<PagerCtl>>>,
         // The size of the tty to start off with
         init_tty_size: TtySize,
+        // The env that the shell will be launched with, we want to use
+        // the same env for the pager program (mostly because we want
+        // to pass TERM along correctly).
+        shell_env: &[(String, String)],
     ) -> anyhow::Result<Option<TtySize>> {
         if let Some(debouncer) = &self.debouncer {
             if !debouncer.should_fire()? {
@@ -109,8 +113,13 @@ impl DailyMessenger {
 
         let pager = Pager::new(pager_bin.to_string());
 
-        let final_size =
-            pager.display(client_stream, ctl_slot, init_tty_size, motd_value.as_str())?;
+        let final_size = pager.display(
+            client_stream,
+            ctl_slot,
+            init_tty_size,
+            motd_value.as_str(),
+            shell_env,
+        )?;
         Ok(Some(final_size))
     }
 

--- a/shpool/tests/data/motd_env_test_script.sh
+++ b/shpool/tests/data/motd_env_test_script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "TERM=${TERM}"
+
+sleep 5

--- a/shpool/tests/data/motd_pager_env_test.toml.tmpl
+++ b/shpool/tests/data/motd_pager_env_test.toml.tmpl
@@ -1,0 +1,12 @@
+norc = true
+noecho = true
+shell = "/bin/bash"
+session_restore_mode = "simple"
+
+[motd.pager]
+# this gets replaced by motd_env_test_script.sh
+bin = "MOTD_ENV_TEST_SCRIPT"
+
+[env]
+PS1 = "prompt> "
+TERM = "testval"


### PR DESCRIPTION
This patch fixes the motd.pager mode to start launching the pager with the same environment that we launch the shell with. The old way of just inheriting the same environment that the daemon has has the problem that it will not correctly match the user's TERM value, which can cause problems for programs like `less` that use the TERM value to determine the right control sequences to emit.

Fixes #129