### PR TITLE
fix: suppress prompt setup in screen restore

### DIFF
--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -471,12 +471,6 @@ impl SessionInner {
                 let mut buf = &buf[..len];
                 trace!("read pty master len={} '{}'", len, String::from_utf8_lossy(buf));
 
-                if !matches!(args.session_restore_mode, config::SessionRestoreMode::Simple) {
-                    if let Some(s) = output_spool.as_mut() {
-                        s.process(buf);
-                    }
-                }
-
                 // scan for control codes we need to handle
                 let mut reset_client_conn = false;
                 if !has_seen_prompt_sentinel {
@@ -490,6 +484,12 @@ impl SessionInner {
                             // drop everything up to and including the sentinel
                             buf = &buf[i + 1..];
                         }
+                    }
+                }
+
+                if !matches!(args.session_restore_mode, config::SessionRestoreMode::Simple) {
+                    if let (Some(s), true) = (output_spool.as_mut(), has_seen_prompt_sentinel) {
+                        s.process(buf);
                     }
                 }
 

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -836,10 +836,13 @@ fn screen_restore() -> anyhow::Result<()> {
             let mut attach_proc =
                 daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
             let mut line_matcher = attach_proc.line_matcher()?;
+            line_matcher.never_matches("^.*SHPOOL_PROMPT_SETUP_SENTINEL.*$")?;
 
             // the re-attach should redraw the screen for us, so we should
             // get a line with "foo" as part of the re-drawn screen.
             line_matcher.scan_until_re("foo$")?;
+
+            attach_proc.proc.kill()?;
         }
 
         Ok(())

--- a/shpool/tests/data/restore_screen.toml
+++ b/shpool/tests/data/restore_screen.toml
@@ -2,7 +2,7 @@ norc = true
 noecho = true
 shell = "/bin/bash"
 session_restore_mode = "screen"
-prompt_prefix = ""
+prompt_prefix = "someprefix "
 
 [env]
 PS1 = "prompt> "

--- a/shpool/tests/support/attach.rs
+++ b/shpool/tests/support/attach.rs
@@ -52,7 +52,7 @@ impl Proc {
         )
         .context("setting stdout nonblocking")?;
 
-        Ok(LineMatcher { out: io::BufReader::new(r) })
+        Ok(LineMatcher { out: io::BufReader::new(r), never_match_regex: vec![] })
     }
 
     /// Create a handle for asserting about stderr output lines.
@@ -65,7 +65,7 @@ impl Proc {
         )
         .context("setting stderr nonblocking")?;
 
-        Ok(LineMatcher { out: io::BufReader::new(r) })
+        Ok(LineMatcher { out: io::BufReader::new(r), never_match_regex: vec![] })
     }
 
     pub fn await_event(&mut self, event: &str) -> anyhow::Result<()> {

--- a/shpool/tests/support/line_matcher.rs
+++ b/shpool/tests/support/line_matcher.rs
@@ -6,14 +6,27 @@ use regex::Regex;
 const CMD_READ_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const CMD_READ_SLEEP_DUR: time::Duration = time::Duration::from_millis(20);
 
-pub struct LineMatcher<R> {
+pub struct LineMatcher<R: std::io::Read> {
     pub out: io::BufReader<R>,
+    /// A list of regular expressions which should never match.
+    pub never_match_regex: Vec<Regex>,
 }
 
 impl<R> LineMatcher<R>
 where
     R: std::io::Read,
 {
+    /// Add a pattern to check to ensure that it never matches.
+    ///
+    /// NOTE: this will cause the line matcher to consume the whole
+    /// output rather than stopping reading at the last match.
+    pub fn never_matches(&mut self, re: &str) -> anyhow::Result<()> {
+        let compiled_re = Regex::new(re)?;
+        self.never_match_regex.push(compiled_re);
+
+        Ok(())
+    }
+
     /// Scan lines until one matches the given regex
     pub fn scan_until_re(&mut self, re: &str) -> anyhow::Result<()> {
         let compiled_re = Regex::new(re)?;
@@ -48,6 +61,8 @@ where
                     }
                 }
             }
+
+            self.check_persistant_assertions(&line)?;
 
             eprint!("scanning for /{}/... ", re);
             if compiled_re.is_match(&line) {
@@ -99,6 +114,8 @@ where
                 }
             }
 
+            self.check_persistant_assertions(&line)?;
+
             // Don't print the whole line so we don't include any control codes.
             // eprintln!("testing /{}/ against '{}'", re, &line);
             eprintln!("testing /{}/ against line", re);
@@ -109,6 +126,68 @@ where
                     .collect()),
                 None => Err(anyhow!("expected /{}/ to match '{}'", re, &line)),
             };
+        }
+    }
+
+    /// Scan through all the remaining lines and ensure that no persistant
+    /// assertions fail (the never match regex).
+    pub fn drain(&mut self) -> anyhow::Result<()> {
+        let start = time::Instant::now();
+        loop {
+            let mut line = String::new();
+            match self.out.read_line(&mut line) {
+                Ok(0) => {
+                    return Ok(());
+                }
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::WouldBlock {
+                        if start.elapsed() > CMD_READ_TIMEOUT {
+                            return Err(io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                "timed out reading line",
+                            ))?;
+                        }
+
+                        std::thread::sleep(CMD_READ_SLEEP_DUR);
+                        continue;
+                    }
+
+                    return Err(e).context("reading line from shell output")?;
+                }
+                Ok(_) => {
+                    if line.ends_with('\n') {
+                        line.pop();
+                        if line.ends_with('\r') {
+                            line.pop();
+                        }
+                    }
+                }
+            }
+
+            self.check_persistant_assertions(&line)?;
+        }
+    }
+
+    fn check_persistant_assertions(&self, line: &str) -> anyhow::Result<()> {
+        for nomatch_re in self.never_match_regex.iter() {
+            if nomatch_re.is_match(line) {
+                return Err(anyhow!("expected /{}/ never to match, but it did", nomatch_re));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<R> std::ops::Drop for LineMatcher<R>
+where
+    R: std::io::Read,
+{
+    fn drop(&mut self) {
+        if !self.never_match_regex.is_empty() {
+            if let Err(e) = self.drain() {
+                panic!("assertion failure during drain: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
This patch starts correctly suppressing the prompt setup code during screen restore. Previously, we
were just suppressing it in terms of the data
we initially stream to the user, but if you create a new session, then disconnect, then reconnect, the setup code would be visible. The fix is to avoid pumping data into the in-memory term until after we've seen the prompt setup sentinel.

I tested that the tweaked test in this patch failes without the application change to ensure that it
is really testing what we want. I also observed this patch working with manual testing.

Fixes #120