### PR TITLE
fix: handle dyn config updates to motd settings

### DIFF
--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -93,10 +93,7 @@ impl Server {
             }
         });
 
-        let daily_messenger = Arc::new(show_motd::DailyMessenger::new(
-            config.get().motd.clone().unwrap_or_default(),
-            config.get().motd_args.clone(),
-        )?);
+        let daily_messenger = Arc::new(show_motd::DailyMessenger::new(config.clone())?);
         Ok(Arc::new(Server {
             config,
             shells,


### PR DESCRIPTION
We were caching some config values, which is a no-no now that we support dynamic config reloading. The
fix is to just always store the manager and access config fields at the last minute as we are supposed to.