### PR TITLE
feat: add span traces at lock() points

### DIFF
--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -559,6 +559,7 @@ impl SessionInner {
         )));
 
         {
+            let _s = span!(Level::INFO, "initial_attach_lock(shell_to_client_ctl)").entered();
             let shell_to_client_ctl = self.shell_to_client_ctl.lock().unwrap();
             shell_to_client_ctl
                 .client_connection
@@ -622,6 +623,7 @@ impl SessionInner {
             // cows to come home.
             let c_done = child_done.load(Ordering::Acquire);
             {
+                let _s = span!(Level::INFO, "disconnect_lock(shell_to_client_ctl)").entered();
                 let shell_to_client_ctl = self.shell_to_client_ctl.lock().unwrap();
                 let send_res = shell_to_client_ctl.client_connection.send_timeout(if c_done {
                     let exit_status = child_exit_notifier
@@ -678,7 +680,7 @@ impl SessionInner {
                 .context("shutting down client stream")?;
         }
 
-        info!("bidi_stream: done child_done={}", c_done);
+        info!("done child_done={}", c_done);
         Ok(c_done)
     }
 

--- a/libshpool/src/daemon/ttl_reaper.rs
+++ b/libshpool/src/daemon/ttl_reaper.rs
@@ -102,6 +102,7 @@ pub fn run(
                         continue;
                     }
 
+                    let _s = span!(Level::INFO, "lock(shells)").entered();
                     let mut shells = shells.lock().unwrap();
                     if let Some(sess) = shells.get(&reapable.session_name) {
                         if let Err(e) = sess.kill() {


### PR DESCRIPTION
This patch adds some span traces at all the points we take locks on the global shells table, the pager_ctl handle and the shell_to_client_ctl handle. This should hopefully make it a bit easier to identify
deadlocks.