### PR TITLE
fix: add space to keybindings grammar

### DIFF
--- a/libshpool/src/daemon/keybindings.rs
+++ b/libshpool/src/daemon/keybindings.rs
@@ -29,7 +29,7 @@
 //!
 //! ```text
 //! sequence ::= chord
-//!            | chord chord
+//!            | chord ' ' chord
 //!
 //! chord ::= key
 //!         | key '-' chord


### PR DESCRIPTION
The documented grammar for keybindings was slightly wrong since it did not show that you need to seperate chords in a sequence with whitespace. This patch
fixes that.