### PR TITLE
refactor: extract session restore related code behind a trait

### DIFF
--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -35,15 +35,9 @@ use crate::{
     consts,
     daemon::{config, exit_notify::ExitNotifier, keybindings, pager::PagerCtl, prompt, show_motd},
     protocol::ChunkExt as _,
-    test_hooks,
+    session_restore, test_hooks,
     tty::TtySizeExt as _,
 };
-
-// To prevent data getting dropped, we set this to be large, but we don't want
-// to use u16::MAX, since the vt100 crate eagerly fills in its rows, and doing
-// so is very memory intensive. The right fix is to get the vt100 crate to
-// lazily initialize its rows, but that is likely a bunch of work.
-const VTERM_WIDTH: u16 = 1024;
 
 const SHELL_KILL_TIMEOUT: time::Duration = time::Duration::from_millis(500);
 
@@ -209,26 +203,19 @@ impl SessionInner {
         let daily_messenger = Arc::clone(&self.daily_messenger);
         let mut needs_initial_motd_dump = self.needs_initial_motd_dump;
 
-        let vterm_width = {
-            let config = self.config.get();
-            config.vt100_output_spool_width.unwrap_or(VTERM_WIDTH)
-        };
         let mut pty_master = self.pty_master.is_parent()?;
         let watchable_master = pty_master;
         let name = self.name.clone();
-        let mut closure = move || {
+        let config = self.config.clone();
+        let closure = move || {
             let _s = span!(Level::INFO, "shell->client", s = name, cid = args.conn_id).entered();
 
-            let mut output_spool =
-                if matches!(args.session_restore_mode, config::SessionRestoreMode::Simple) {
-                    None
-                } else {
-                    Some(shpool_vt100::Parser::new(
-                        args.tty_size.rows,
-                        vterm_width,
-                        args.scrollback_lines,
-                    ))
-                };
+            let mut output_spool = session_restore::new(
+                config,
+                &args.session_restore_mode,
+                &args.tty_size,
+                args.scrollback_lines,
+            );
             let mut buf: Vec<u8> = vec![0; consts::BUF_SIZE];
             let mut poll_fds = [poll::PollFd::new(
                 watchable_master.borrow_fd().ok_or(anyhow!("no master fd"))?,
@@ -265,7 +252,12 @@ impl SessionInner {
                                 } else {
                                     ClientConnectionStatus::New
                                 };
-                                // Resize the pty to be bigger than it needs to be,
+
+                                // Always instantly resize the spool, since we don't
+                                // need to inject a delay into that.
+                                output_spool.resize(conn.size.clone());
+
+                                // First resize the pty to be bigger than it needs to be,
                                 // we do this immediately so that the extra size
                                 // can "bake" for a little bit, which emacs seems
                                 // to require in order to pick up the jiggle.
@@ -277,11 +269,7 @@ impl SessionInner {
                                 };
                                 oversize.set_fd(pty_master.raw_fd().ok_or(anyhow!("no master fd"))?)?;
 
-                                // Always instantly resize the spool, since we don't
-                                // need to inject a delay into that.
-                                if let Some(s) = output_spool.as_mut() {
-                                    s.screen_mut().set_size(conn.size.rows, u16::MAX);
-                                }
+                                // Prepare a resize command for pty to execute later.
                                 resize_cmd = Some(ResizeCmd {
                                     size: conn.size.clone(),
                                     when: time::Instant::now().add(REATTACH_RESIZE_DELAY),
@@ -340,9 +328,7 @@ impl SessionInner {
                         match new_size {
                             Ok(size) => {
                                 info!("resize size={:?}", size);
-                                if let Some(s) = output_spool.as_mut() {
-                                    s.screen_mut().set_size(size.rows, u16::MAX);
-                                }
+                                output_spool.resize(size.clone());
                                 resize_cmd = Some(ResizeCmd {
                                     size,
                                     // No delay needed for ordinary resizes, just
@@ -384,28 +370,8 @@ impl SessionInner {
                 }
 
                 if do_reattach {
-                    use config::SessionRestoreMode::*;
-
-                    info!("executing reattach protocol (mode={:?})", args.session_restore_mode);
-                    let restore_buf = match (output_spool.as_mut(), &args.session_restore_mode) {
-                        (Some(spool), Screen) => {
-                            let (rows, cols) = spool.screen().size();
-                            info!(
-                                "computing screen restore buf with (rows={}, cols={})",
-                                rows, cols
-                            );
-                            spool.screen().contents_formatted()
-                        }
-                        (Some(spool), Lines(nlines)) => {
-                            let (rows, cols) = spool.screen().size();
-                            info!(
-                                "computing lines({}) restore buf with (rows={}, cols={})",
-                                nlines, rows, cols
-                            );
-                            spool.screen().last_n_rows_contents_formatted(*nlines)
-                        }
-                        (_, _) => vec![],
-                    };
+                    info!("executing reattach protocol (mode={:?})", &args.session_restore_mode);
+                    let restore_buf = output_spool.current_contents();
                     if let (true, ClientConnectionMsg::New(conn)) =
                         (!restore_buf.is_empty(), &client_conn)
                     {
@@ -472,11 +438,7 @@ impl SessionInner {
                     }
                 }
 
-                if !matches!(args.session_restore_mode, config::SessionRestoreMode::Simple) {
-                    if let (Some(s), true) = (output_spool.as_mut(), has_seen_prompt_sentinel) {
-                        s.process(buf);
-                    }
-                }
+                output_spool.process(buf);
 
                 if let (ClientConnectionMsg::New(conn), true) =
                     (&client_conn, has_seen_prompt_sentinel)

--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -40,6 +40,7 @@ mod hooks;
 mod kill;
 mod list;
 mod protocol;
+mod session_restore;
 mod test_hooks;
 mod tty;
 mod user;

--- a/libshpool/src/session_restore/mod.rs
+++ b/libshpool/src/session_restore/mod.rs
@@ -1,0 +1,117 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use shpool_protocol::TtySize;
+use tracing::info;
+
+use crate::config::{self, SessionRestoreMode};
+
+// To prevent data getting dropped, we set this to be large, but we don't want
+// to use u16::MAX, since the vt100 crate eagerly fills in its rows, and doing
+// so is very memory intensive. The right fix is to get the vt100 crate to
+// lazily initialize its rows, but that is likely a bunch of work.
+const VTERM_WIDTH: u16 = 1024;
+
+pub trait SessionSpool {
+    /// Resizes the internal representation to new tty size.
+    fn resize(&mut self, size: TtySize);
+
+    /// Gets the current content as a byte buffer.
+    fn current_contents(&self) -> Vec<u8>;
+
+    /// Process bytes from pty master.
+    fn process(&mut self, bytes: &[u8]);
+}
+
+/// A spool that doesn't do anything.
+pub struct NullSpool;
+impl SessionSpool for NullSpool {
+    fn resize(&mut self, _: TtySize) {}
+
+    fn current_contents(&self) -> Vec<u8> {
+        vec![]
+    }
+
+    fn process(&mut self, _: &[u8]) {}
+}
+
+/// A spool that restores the last screenful of content using shpool_vt100.
+pub struct Vt100Screen {
+    parser: shpool_vt100::Parser,
+}
+
+impl SessionSpool for Vt100Screen {
+    fn resize(&mut self, size: TtySize) {
+        // TODO(pfyu): why u16::MAX? shouldn't this be vterm_width?
+        self.parser.screen_mut().set_size(size.rows, u16::MAX);
+    }
+
+    fn current_contents(&self) -> Vec<u8> {
+        let (rows, cols) = self.parser.screen().size();
+        info!("computing screen restore buf with (rows={}, cols={})", rows, cols);
+        self.parser.screen().contents_formatted()
+    }
+
+    fn process(&mut self, bytes: &[u8]) {
+        self.parser.process(bytes)
+    }
+}
+
+/// A spool that restores the last n lines of content using shpool_vt100.
+pub struct Vt100Lines {
+    parser: shpool_vt100::Parser,
+    /// How many lines to restore
+    nlines: u16,
+}
+
+impl SessionSpool for Vt100Lines {
+    fn resize(&mut self, size: TtySize) {
+        // TODO(pfyu): why u16::MAX? shouldn't this be vterm_width?
+        self.parser.screen_mut().set_size(size.rows, u16::MAX);
+    }
+
+    fn current_contents(&self) -> Vec<u8> {
+        let (rows, cols) = self.parser.screen().size();
+        info!("computing lines({}) restore buf with (rows={}, cols={})", self.nlines, rows, cols);
+        self.parser.screen().last_n_rows_contents_formatted(self.nlines)
+    }
+
+    fn process(&mut self, bytes: &[u8]) {
+        self.parser.process(bytes)
+    }
+}
+
+/// Creates a spool given a `mode`.
+pub fn new(
+    config: config::Manager,
+    mode: &SessionRestoreMode,
+    size: &TtySize,
+    scrollback_lines: usize,
+) -> Box<dyn SessionSpool + 'static> {
+    let vterm_width = {
+        let config = config.get();
+        config.vt100_output_spool_width.unwrap_or(VTERM_WIDTH)
+    };
+
+    match mode {
+        SessionRestoreMode::Simple => Box::new(NullSpool),
+        SessionRestoreMode::Screen => Box::new(Vt100Screen {
+            parser: shpool_vt100::Parser::new(size.rows, vterm_width, scrollback_lines),
+        }),
+        SessionRestoreMode::Lines(nlines) => Box::new(Vt100Lines {
+            parser: shpool_vt100::Parser::new(size.rows, vterm_width, scrollback_lines),
+            nlines: *nlines,
+        }),
+    }
+}


### PR DESCRIPTION
This prepares us for more session restore backends in the future.