### PR TITLE
fix: reduce deadlock potential in shell->client

### DIFF
--- a/libshpool/src/config_watcher.rs
+++ b/libshpool/src/config_watcher.rs
@@ -321,21 +321,18 @@ impl<Handler> ConfigWatcherInner<Handler> {
                 self.paths.drain().map(|(path, (watched_path, _))| (path, watched_path)).collect()
             }
         };
-        rewatch_paths
-            .into_iter()
-            .map(|(path, watched_path)| {
-                if let Err(err) = self.watcher.unwatch(&watched_path) {
-                    // error sometimes is expected if the watched_path was simply removed, in that
-                    // case notify will automatically remove the watch.
-                    error!("error unwatch {:?}", err);
-                } else {
-                    debug!("unwatched {}", watched_path.display());
-                }
-                watch_and_add(&mut self.watcher, self.paths.entry(path))
-                    .map_err(|err| error!("Failed to add watch: {:?}", err))
-                    .unwrap_or(true)
-            })
-            .any(|reload| reload)
+        rewatch_paths.into_iter().any(|(path, watched_path)| {
+            if let Err(err) = self.watcher.unwatch(&watched_path) {
+                // error sometimes is expected if the watched_path was simply removed, in that
+                // case notify will automatically remove the watch.
+                error!("error unwatch {:?}", err);
+            } else {
+                debug!("unwatched {}", watched_path.display());
+            }
+            watch_and_add(&mut self.watcher, self.paths.entry(path))
+                .map_err(|err| error!("Failed to add watch: {:?}", err))
+                .unwrap_or(true)
+        })
     }
 }
 

--- a/libshpool/src/test_hooks.rs
+++ b/libshpool/src/test_hooks.rs
@@ -92,7 +92,7 @@ impl TestHookServer {
         for _ in 0..12 {
             {
                 let clients = self.clients.lock().unwrap();
-                if clients.len() > 0 {
+                if !clients.is_empty() {
                     return Ok(());
                 }
             }

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+
 use std::{
     env,
     ffi::OsStr,

--- a/shpool/tests/detach.rs
+++ b/shpool/tests/detach.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+
 use std::process::Command;
 
 use anyhow::Context;

--- a/shpool/tests/kill.rs
+++ b/shpool/tests/kill.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+
 use std::{env, process::Command};
 
 use anyhow::Context;
@@ -104,10 +106,10 @@ fn single_attached() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         Ok(())
     })
@@ -136,10 +138,10 @@ fn multiple_attached() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         Ok(())
     })
@@ -169,10 +171,10 @@ fn reattach_after_kill() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         waiter.wait_event("daemon-handle-kill-removed-shells")?;
         waiter.wait_event("daemon-bidi-stream-done")?;
@@ -210,10 +212,10 @@ fn single_detached() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         Ok(())
     })
@@ -248,10 +250,10 @@ fn multiple_detached() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         Ok(())
     })
@@ -286,10 +288,10 @@ fn multiple_mixed() -> anyhow::Result<()> {
         assert!(out.status.success());
 
         let stdout = String::from_utf8_lossy(&out.stdout[..]);
-        assert!(stdout.len() == 0);
+        assert!(stdout.is_empty());
 
         let stderr = String::from_utf8_lossy(&out.stderr[..]);
-        assert!(stderr.len() == 0);
+        assert!(stderr.is_empty());
 
         Ok(())
     })


### PR DESCRIPTION
This patch attempts to reduce the potential to deadlock in the shell->client thread by removing the mutex lock around the shell->client unix socket stream. While recent changes to reduce deadlocks have successfully prevented a single locked session from gumming up all the other sessions, the core issue seems to be persisting. I don't see a smoking gun in the logs that a reporter sent me, but reducing the number of locks in the shell->client thread, which seems to be the one that gets locked up, might help. This should also be slight better for performance (not that it really matters here).

In addition to that main change, this patch contains a few little bugfixes:

- Previously, every time the client probed for daemon presence, the daemon would put a distracting stack trace in its log. This wasn't a real issue, but it could be confusing for people not familiar with how shpool works. I've had a few people point to it in bug reports. I suppressed the stack trace and replaced it with a more civilized log line. Stack traces in the logs should be indicative of an issue, not business as usual.

- I fixed the child_watcher thread to directly call waitpid rather than using the shpool_pty crate to do the work. This isn't ideal, but is required to avoid a use-after-close issue that was causing trouble. I think this bug was already present, but it just wasn't presenting a problem during tests for whatever reason (likely just timing). I had to fix this to get the tests passing.