### PR TITLE
fix: use MSRV aware resolver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# use MSRV aware resolver
+[resolver]
+incompatible-rust-versions = "fallback"


### PR DESCRIPTION
This configures cargo to use the MSRV aware resolver, which should hopefully prevent future release woes.