### PR TITLE
chore: upgrade nix to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -539,7 +539,7 @@ dependencies = [
  "libproc",
  "log",
  "motd",
- "nix 0.28.0",
+ "nix",
  "notify",
  "ntest",
  "rmp-serde",
@@ -575,15 +575,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -626,28 +617,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -748,12 +726,6 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro-crate"
@@ -947,7 +919,7 @@ dependencies = [
  "crossbeam-channel",
  "lazy_static",
  "libshpool",
- "nix 0.26.4",
+ "nix",
  "ntest",
  "regex",
  "serde_json",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -47,7 +47,7 @@ shpool-protocol = { version = "0.2.1", path = "../shpool-protocol" } # client-se
 
 # rusty wrapper for unix apis
 [dependencies.nix]
-version = "0.28"
+version = "0.29"
 features = ["poll", "ioctl", "socket", "user", "process", "signal", "term", "fs"]
 
 [dependencies.tracing-subscriber]

--- a/shpool/Cargo.toml
+++ b/shpool/Cargo.toml
@@ -23,8 +23,12 @@ libshpool = { version = "0.8.2", path = "../libshpool" }
 [dev-dependencies]
 lazy_static = "1" # globals
 crossbeam-channel = "0.5" # channels
-nix = { version = "0.26", features = ["poll", "ioctl"] } # rusty wrapper for unix apis
 tempfile = "3" # keeping tests hermetic
 regex = "1" # test assertions
 serde_json = "1" # json parsing
 ntest = "0.9" # test timeouts
+
+# rusty wrapper for unix apis
+[dependencies.nix]
+version = "0.29"
+features = ["poll", "ioctl", "process", "signal", "fs"]


### PR DESCRIPTION
This patch updates our nix dependency to 0.29.
We didn't have to do anything for libshpool, but
I had to make some tweaks to the test code. I
was even able to delete an `unsafe` block, which
is always nice.