### PR TITLE
fix: vterm width

### DIFF
--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -287,7 +287,7 @@ impl SessionInner {
                                 // Always instantly resize the spool, since we don't
                                 // need to inject a delay into that.
                                 if let Some(s) = output_spool.as_mut() {
-                                    s.screen_mut().set_size(conn.size.rows, u16::MAX);
+                                    s.screen_mut().set_size(conn.size.rows, VTERM_WIDTH);
                                 }
                                 resize_cmd = Some(ResizeCmd {
                                     size: conn.size.clone(),
@@ -348,7 +348,7 @@ impl SessionInner {
                             Ok(size) => {
                                 info!("resize size={:?}", size);
                                 if let Some(s) = output_spool.as_mut() {
-                                    s.screen_mut().set_size(size.rows, u16::MAX);
+                                    s.screen_mut().set_size(size.rows, VTERM_WIDTH);
                                 }
                                 resize_cmd = Some(ResizeCmd {
                                     size,


### PR DESCRIPTION
I thought we had already dealt with this bug, but apparently not. This patch fixes the shell->client thread to always use VTERM_WIDTH when resizing the in memory terminal.