### PR TITLE
fix: remove ansi color codes from logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "sharded-slab",
  "smallvec",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.28"
 features = ["poll", "ioctl", "socket", "user", "process", "signal", "term", "fs"]
 
 [dependencies.tracing-subscriber]
-version = "0.3"
+version = "0.3.19"
 default-features = false
 features = ["std", "fmt", "tracing-log", "smallvec"]
 

--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -199,6 +199,7 @@ pub fn run(args: Args, hooks: Option<Box<dyn hooks::Hooks + Send + Sync>>) -> an
     if let Some(log_file) = args.log_file.clone() {
         let file = fs::File::create(log_file)?;
         tracing_subscriber::fmt()
+            .with_ansi(false)
             .with_max_level(trace_level)
             .with_thread_ids(true)
             .with_target(false)
@@ -207,6 +208,7 @@ pub fn run(args: Args, hooks: Option<Box<dyn hooks::Hooks + Send + Sync>>) -> an
             .init();
     } else if let Commands::Daemon = args.command {
         tracing_subscriber::fmt()
+            .with_ansi(false)
             .with_max_level(trace_level)
             .with_thread_ids(true)
             .with_target(false)


### PR DESCRIPTION
These colors look nice when sent to a terminal, but are really annoying when in a log file. I mostly interact with logs when users post them due to bugs, so getting rid of the colors will make life easier.