### PR TITLE
fix: release plz pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e
         with:
-          inherit-toolchain: true
           bins: cross
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@ca8762285a5dc0c220cb4a7896c9986ff6c97ecf


### PR DESCRIPTION
The release pipeline is still broken even after my attempt to fix it with b99a1af6.

https://github.com/shell-pool/shpool/actions/runs/13316122235/job/37190478131#step:5:292 shows the problem.