### PR TITLE
feat: add dynamic log level msg to shpool-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,10 @@ dependencies = [
 
 [[package]]
 name = "shpool-protocol"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
+ "clap",
  "serde",
  "serde_derive",
 ]

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -43,7 +43,7 @@ strip-ansi-escapes = "0.2.0" # cleaning up strings for pager display
 notify = { version = "7", features = ["crossbeam-channel"] }  # watch config file for updates
 libproc = "0.14.8" # sniffing shells by examining the subprocess
 daemonize = "0.5" # autodaemonization
-shpool-protocol = { version = "0.2.1", path = "../shpool-protocol" } # client-server protocol
+shpool-protocol = { version = "0.3.0", path = "../shpool-protocol" } # client-server protocol
 
 # rusty wrapper for unix apis
 [dependencies.nix]

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -189,6 +189,7 @@ impl Server {
             ConnectHeader::Kill(r) => self.handle_kill(stream, r),
             ConnectHeader::List => self.handle_list(stream),
             ConnectHeader::SessionMessage(header) => self.handle_session_message(stream, header),
+            ConnectHeader::SetLogLevel(_) => unimplemented!(),
         }
     }
 

--- a/shpool-protocol/Cargo.toml
+++ b/shpool-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shpool-protocol"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Ethan Pailes <pailes@google.com>"]
 repository = "https://github.com/shell-pool/shpool"
@@ -17,3 +17,4 @@ rust-version = "1.74"
 anyhow = "1"
 serde = "1"
 serde_derive = "1"
+clap = { version = "4", features = ["derive"] } # cli parsing

--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -15,6 +15,7 @@
 use std::{default::Default, fmt};
 
 use anyhow::anyhow;
+use clap::ValueEnum;
 use serde_derive::{Deserialize, Serialize};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -60,6 +61,8 @@ pub enum ConnectHeader {
     /// A message to request that a list of running
     /// sessions get killed.
     Kill(KillRequest),
+    // A request to set the log level to a new value.
+    SetLogLevel(SetLogLevelRequest),
 }
 
 /// KillRequest represents a request to kill
@@ -96,6 +99,28 @@ pub struct DetachReply {
     #[serde(default)]
     pub not_attached_sessions: Vec<String>,
 }
+
+#[derive(Serialize, Deserialize, Debug, Default, ValueEnum, Clone)]
+pub enum LogLevel {
+    #[default]
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+// SetLogLevelRequest contains a request to set a new
+// log level
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SetLogLevelRequest {
+    #[serde(default)]
+    pub level: LogLevel,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SetLogLevelReply {}
 
 /// SessionMessageRequest represents a request that
 /// ought to be routed to the session indicated by


### PR DESCRIPTION
This patch adds a new dynamic log level adjustment message to the shpool-protocol crate. This is a
breaking change for the protocol, but won't result in a breaking change for libshpool.

This is progress on #117