### PR TITLE
feat: allow daemon log level to dynamically change

### DIFF
--- a/libshpool/src/daemon/mod.rs
+++ b/libshpool/src/daemon/mod.rs
@@ -37,6 +37,10 @@ pub fn run(
     config_manager: config::Manager,
     runtime_dir: PathBuf,
     hooks: Box<dyn hooks::Hooks + Send + Sync>,
+    log_level_handle: tracing_subscriber::reload::Handle<
+        tracing_subscriber::filter::LevelFilter,
+        tracing_subscriber::registry::Registry,
+    >,
     socket: PathBuf,
 ) -> anyhow::Result<()> {
     if let Ok(daemonize) = env::var(consts::AUTODAEMONIZE_VAR) {
@@ -52,7 +56,7 @@ pub fn run(
 
     info!("\n\n======================== STARTING DAEMON ============================\n\n");
 
-    let server = server::Server::new(config_manager, hooks, runtime_dir)?;
+    let server = server::Server::new(config_manager, hooks, runtime_dir, log_level_handle)?;
 
     let (cleanup_socket, listener) = match systemd::activation_socket() {
         Ok(l) => {

--- a/libshpool/src/set_log_level.rs
+++ b/libshpool/src/set_log_level.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{io, path::PathBuf};
+
+use anyhow::Context;
+use shpool_protocol::{ConnectHeader, LogLevel, SetLogLevelReply, SetLogLevelRequest};
+
+use crate::{protocol, protocol::ClientResult};
+
+pub fn run(level: LogLevel, socket: PathBuf) -> anyhow::Result<()> {
+    let mut client = match protocol::Client::new(socket) {
+        Ok(ClientResult::JustClient(c)) => c,
+        Ok(ClientResult::VersionMismatch { warning, client }) => {
+            eprintln!("warning: {}, try restarting your daemon", warning);
+            client
+        }
+        Err(err) => {
+            let io_err = err.downcast::<io::Error>()?;
+            if io_err.kind() == io::ErrorKind::NotFound {
+                eprintln!("could not connect to daemon");
+            }
+            return Err(io_err).context("connecting to daemon");
+        }
+    };
+
+    client
+        .write_connect_header(ConnectHeader::SetLogLevel(SetLogLevelRequest { level }))
+        .context("sending set-log-level header")?;
+    let _reply: SetLogLevelReply = client.read_reply().context("reading reply")?;
+
+    Ok(())
+}

--- a/shpool/tests/list.rs
+++ b/shpool/tests/list.rs
@@ -43,6 +43,7 @@ fn version_mismatch_client_newer() -> anyhow::Result<()> {
                     String::from("SHPOOL_TEST__OVERRIDE_VERSION"),
                     String::from("0.0.0"),
                 )],
+                ..Default::default()
             },
         )
         .context("starting daemon proc")?;
@@ -69,6 +70,7 @@ fn version_mismatch_client_older() -> anyhow::Result<()> {
                     String::from("SHPOOL_TEST__OVERRIDE_VERSION"),
                     String::from("99999.0.0"),
                 )],
+                ..Default::default()
             },
         )
         .context("starting daemon proc")?;


### PR DESCRIPTION
This patch adds a new subcommand to allow dynamically changing
the log level. This should hopefully make it easier to debug
some issues where we can't restart to crank up the verbosity.

Fixes #117

BREAKING CHANGE: the libshpool api has has a new enum variant