### PR TITLE
fix: eval SHPOOL__OLD_PROMPT_COMMAND rather than iterate sub-components

### DIFF
--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -68,15 +68,11 @@ pub fn maybe_inject_prefix(
                SHPOOL__OLD_PS1="${{PS1}}"
                function __shpool__prompt_command() {{
                   PS1="${{SHPOOL__OLD_PS1}}"
-                  if [[ "$(declare -a SHPOOL__OLD_PROMPT_COMMAND)" =~ "declare -a" ]]; then
-                    for prompt_hook in "${{SHPOOL__OLD_PROMPT_COMMAND[@]}}"
-                    do
-                      ${{prompt_hook}}
-                    done
-                  else
-                    eval "${{SHPOOL__OLD_PROMPT_COMMAND}}"
-                  fi
-                  PS1="${prompt_prefix}${{PS1}}"
+                  for prompt_hook in "${{SHPOOL__OLD_PROMPT_COMMAND[@]}}"
+                  do
+                    eval "${{prompt_hook}}"
+                  done
+                  PS1="{prompt_prefix}${{PS1}}"
                }}
                PROMPT_COMMAND=__shpool__prompt_command
             fi

--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -67,8 +67,16 @@ pub fn maybe_inject_prefix(
                SHPOOL__OLD_PROMPT_COMMAND="${{PROMPT_COMMAND}}"
                SHPOOL__OLD_PS1="${{PS1}}"
                function __shpool__prompt_command() {{
-                  eval "${{SHPOOL__OLD_PROMPT_COMMAND}}"
-                  PS1="{prompt_prefix}${{SHPOOL__OLD_PS1}}"
+                  PS1="${{SHPOOL__OLD_PS1}}"
+                  if [[ "$(declare -a SHPOOL__OLD_PROMPT_COMMAND)" =~ "declare -a" ]]; then
+                    for prompt_hook in "${{SHPOOL__OLD_PROMPT_COMMAND[@]}}"
+                    do
+                      ${{prompt_hook}}
+                    done
+                  else
+                    eval "${{SHPOOL__OLD_PROMPT_COMMAND}}"
+                  fi
+                  PS1="${prompt_prefix}${{PS1}}"
                }}
                PROMPT_COMMAND=__shpool__prompt_command
             fi

--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -64,7 +64,7 @@ pub fn maybe_inject_prefix(
             if [[ -z "${{PROMPT_COMMAND+x}}" ]]; then
                PS1="{prompt_prefix}${{PS1}}"
             else
-               SHPOOL__OLD_PROMPT_COMMAND="${{PROMPT_COMMAND}}"
+               SHPOOL__OLD_PROMPT_COMMAND=("${{PROMPT_COMMAND[@]}}")
                SHPOOL__OLD_PS1="${{PS1}}"
                function __shpool__prompt_command() {{
                   PS1="${{SHPOOL__OLD_PS1}}"

--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -67,12 +67,8 @@ pub fn maybe_inject_prefix(
                SHPOOL__OLD_PROMPT_COMMAND="${{PROMPT_COMMAND}}"
                SHPOOL__OLD_PS1="${{PS1}}"
                function __shpool__prompt_command() {{
-                  PS1="${{SHPOOL__OLD_PS1}}"
-                  for prompt_hook in ${{SHPOOL__OLD_PROMPT_COMMAND}}
-                  do
-                    ${{prompt_hook}}
-                  done
-                  PS1="{prompt_prefix}${{PS1}}"
+                  eval "${{SHPOOL__OLD_PROMPT_COMMAND}}"
+                  PS1="{prompt_prefix}${{SHPOOL__OLD_PS1}}"
                }}
                PROMPT_COMMAND=__shpool__prompt_command
             fi


### PR DESCRIPTION
👋 hey Ethan, awesome project! Excited to forget how to reconfigure tmux to have vim keybindings (that still don't really make sense to me 😅).

This PR attempts to fix #95

I was running into this same issue on some of my machines. Looks like some distros, when using bash, may set `$PROMPT_COMMAND` to something with whitespace. Though, I'm curious if there's a case where we wouldn't want to `eval ${PROMPT_COMMAND}`.

### ✅ Ubuntu Server (22.04)
```shell
builder@android-builder:~$ shpool attach main

shpool:main builder@android-builder:~$
builder@android-builder:~$ echo $PROMPT_COMMAND

builder@android-builder:~$ echo $PS1
\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$
```

### ✅ Ubuntu (on DigitalOcean's custom image)
```shell
root@bunt:~# echo $PROMPT_COMMAND

root@bunt:~# echo $PS1
\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\u@\h:\w\$
```

### ❗ Endeavour - Issue
```
[isaac@isaac-endeavour ~]$ shpool attach main

printf: usage: printf [-v var] format [arguments]
-bash: "\033]0;%s@%s:%s\007": command not found
-bash: "${USER}": command not found
-bash: "${HOSTNAME%%.*}": command not found
-bash: "${PWD/#$HOME/\~}": No such file or directory
[isaac@isaac-endeavour ~]$ echo $PROMPT_COMMAND
printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
```

### ❗ Fedora release 41 (Forty One)
```
isaac@flow:~$ shpool attach main

printf: usage: printf [-v var] format [arguments]
-bash: "\033]0;%s@%s:%s\007": command not found
-bash: "${USER}": command not found
-bash: "${HOSTNAME%%.*}": command not found
-bash: "${PWD/#$HOME/\~}": No such file or directory
isaac@flow:~/shpool/shpool$ echo $PROMPT_COMMAND
printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
isaac@flow:~/shpool/shpool$ echo $PS1
${PROMPT_START@P}\[\e[${PROMPT_COLOR}${PROMPT_HIGHLIGHT:+;$PROMPT_HIGHLIGHT}m\]${PROMPT_USERHOST@P}\[\e[0m\]${PROMPT_SEPARATOR@P}\[\e[${PROMPT_DIR_COLOR-${PROMPT_COLOR}}${PROMPT_HIGHLIGHT:+;$PROMPT_HIGHLIGHT}m\]${PROMPT_DIRECTORY@P}\[\e[0m\]${PROMPT_END@P}\$\[\e[0m\]
```

Here's the relevant snippet from Fedora's `/etc/bashrc`:
```bash
  if [ "$PS1" ]; then
    if [ -z "$PROMPT_COMMAND" ]; then
      declare -a PROMPT_COMMAND
      case $TERM in
      xterm*)
        if [ -e /etc/sysconfig/bash-prompt-xterm ]; then
            PROMPT_COMMAND=/etc/sysconfig/bash-prompt-xterm
        else
            PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
        fi
        ;;
      screen*)
        if [ -e /etc/sysconfig/bash-prompt-screen ]; then
            PROMPT_COMMAND=/etc/sysconfig/bash-prompt-screen
        else
            PROMPT_COMMAND='printf "\033k%s@%s:%s\033\\" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
        fi
        ;;
      *)
        [ -e /etc/sysconfig/bash-prompt-default ] && PROMPT_COMMAND=/etc/sysconfig/bash-prompt-default
        ;;
      esac
    fi
```

And from Endeavour's `/etc/bash.bashrc`
```bash
case ${TERM} in
  Eterm*|alacritty*|aterm*|foot*|gnome*|konsole*|kterm*|putty*|rxvt*|tmux*|xterm*)
    PROMPT_COMMAND+=('printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"')

    ;;
  screen*)
    PROMPT_COMMAND+=('printf "\033_%s@%s:%s\033\\" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"')
    ;;
esac
```