### PR TITLE
shpool_vt100: 0.1.2 -> 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,9 +573,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -950,14 +950,14 @@ dependencies = [
 
 [[package]]
 name = "shpool_vt100"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a06c7404cb9956f07e8c208f40386eca47db552b611878c839a37a770e908fb"
+checksum = "e839aaacba63b9c8fba16affed9507042eb33d802cf8040c4a6f37e3945029c3"
 dependencies = [
  "itoa",
  "log",
  "unicode-width",
- "vte 0.12.1",
+ "vte 0.15.0",
 ]
 
 [[package]]
@@ -1192,13 +1192,12 @@ dependencies = [
 
 [[package]]
 name = "vte"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b0a06c0f086f7abe70cf308967153479e223b6a9809f7dcc6c47b045574bc9"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
+ "memchr",
 ]
 
 [[package]]

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -34,7 +34,7 @@ libc = "0.2" # basic libc types
 log = "0.4" # logging facade (not used directly, but required if we have tracing-log enabled)
 tracing = "0.1" # logging and performance monitoring facade
 rmp-serde = "1" # serialization for the control protocol
-shpool_vt100 = "0.1.2" # terminal emulation for the scrollback buffer
+shpool_vt100 = "0.1.3" # terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
 motd = { version = "0.2.2", default-features = false, features = [] } # getting the message-of-the-day
 termini = "1.0.0" # terminfo database


### PR DESCRIPTION
This patch bumps the shpool_vt100 version to pick
up a vte upgrade I made to it.