### PR TITLE
feat: dump forward_env in file

### DIFF
--- a/libshpool/src/daemon/pager.rs
+++ b/libshpool/src/daemon/pager.rs
@@ -31,6 +31,7 @@
 */
 
 use std::{
+    ffi::OsString,
     io,
     io::{Read, Write},
     os::{
@@ -105,7 +106,7 @@ impl Pager {
         // The message to display
         msg: &str,
         // The env to launch the pager proc with
-        shell_env: &[(String, String)],
+        shell_env: &[(OsString, OsString)],
     ) -> anyhow::Result<TtySize> {
         let (tty_size_change_tx, tty_size_change_rx) = crossbeam_channel::bounded(0);
         let (tty_size_change_ack_tx, tty_size_change_ack_rx) = crossbeam_channel::bounded(0);

--- a/libshpool/src/daemon/show_motd.rs
+++ b/libshpool/src/daemon/show_motd.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    ffi::OsString,
     io,
     os::unix::net::UnixStream,
     sync::{Arc, Mutex},
@@ -97,7 +98,7 @@ impl DailyMessenger {
         // The env that the shell will be launched with, we want to use
         // the same env for the pager program (mostly because we want
         // to pass TERM along correctly).
-        shell_env: &[(String, String)],
+        shell_env: &[(OsString, OsString)],
     ) -> anyhow::Result<Option<TtySize>> {
         if let Some(debouncer) = &self.debouncer {
             if !debouncer.should_fire()? {


### PR DESCRIPTION
This patch teaches shpool to dump the environment
forwarded from the attach shell in $SHPOOL_SESSION_DIR/forard.env on every reattach. Previously, these env var bindings would only impact the initial environment when the shell is first spawned. Dumping the vars to a file allows users to keep their environment up to date via scripts if they so desire.

This should help a little with #111, though it doesn't solve the issue perfectly.

I'll need to follow this up with documentation once it merges and gets released. We may also want to consider doing something like automatically touching a
$SHPOOL_SESSION_DIR/forward.env.needs_refresh
file on reattach and then sourcing forward.env and removing the marker file within our prompt hook.