### PR TITLE
feat: add -d/--dir flag

### DIFF
--- a/libshpool/src/config.rs
+++ b/libshpool/src/config.rs
@@ -224,6 +224,11 @@ pub struct Config {
     /// initial shell
     pub env: Option<HashMap<String, String>>,
 
+    /// The directory to start new shells in. If this is '$HOME'
+    /// (the default) this will start in the user's home directory.
+    /// If it is '.', it will start wherever `shpool attach` is invoked.
+    pub default_dir: Option<String>,
+
     /// A list of environment variables to forward from the environment
     /// of the initial shell that invoked `shpool attach` to the newly
     /// launched shell. Note that this config option has no impact when
@@ -303,6 +308,7 @@ impl Config {
             nodaemonize_timeout: self.nodaemonize_timeout.or(another.nodaemonize_timeout),
             shell: self.shell.or(another.shell),
             env: self.env.or(another.env),
+            default_dir: self.default_dir.or(another.default_dir),
             forward_env: self.forward_env.or(another.forward_env),
             initial_path: self.initial_path.or(another.initial_path),
             session_restore_mode: self.session_restore_mode.or(another.session_restore_mode),

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -721,7 +721,12 @@ impl Server {
             cmd
         };
 
-        cmd.current_dir(user_info.home_dir.clone())
+        let start_dir = match header.dir.as_deref() {
+            None => user_info.home_dir.clone(),
+            Some(path) => String::from(path),
+        };
+        info!("spawning shell in '{}'", start_dir);
+        cmd.current_dir(start_dir)
             .stdin(process::Stdio::inherit())
             .stdout(process::Stdio::inherit())
             .stderr(process::Stdio::inherit())

--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -151,6 +151,14 @@ The command is broken up into a binary to invoke and a list of arguments to
 pass to the binary using the shell-words crate."
         )]
         cmd: Option<String>,
+        #[clap(
+            short,
+            long,
+            long_help = "The directory to start the shell in.
+
+$HOME by default. Use '.' for pwd."
+        )]
+        dir: Option<String>,
         #[clap(help = "The name of the shell session to create or attach to")]
         name: String,
     },
@@ -357,8 +365,8 @@ pub fn run(args: Args, hooks: Option<Box<dyn hooks::Hooks + Send + Sync>>) -> an
             log_level_handle,
             socket,
         ),
-        Commands::Attach { force, ttl, cmd, name } => {
-            attach::run(config_manager, name, force, ttl, cmd, socket)
+        Commands::Attach { force, ttl, cmd, dir, name } => {
+            attach::run(config_manager, name, force, ttl, cmd, dir, socket)
         }
         Commands::Detach { sessions } => detach::run(sessions, socket),
         Commands::Kill { sessions } => kill::run(sessions, socket),

--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -213,6 +213,10 @@ pub struct AttachHeader {
     /// If specified, a command to run instead of the users default shell.
     #[serde(default)]
     pub cmd: Option<String>,
+    /// If specified, the directory to start the shell in. If not, $HOME
+    /// should be used.
+    #[serde(default)]
+    pub dir: Option<String>,
 }
 
 impl AttachHeader {

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1652,6 +1652,51 @@ fn autodaemonize() -> anyhow::Result<()> {
 
 #[test]
 #[timeout(30000)]
+fn config_tmp_default_dir() -> anyhow::Result<()> {
+    support::dump_err(|| {
+        let mut daemon_proc =
+            support::daemon::Proc::new("tmp_default_dir.toml", DaemonArgs::default())
+                .context("starting daemon proc")?;
+        let mut attach_proc = daemon_proc
+            .attach(
+                "sh1",
+                AttachArgs {
+                    config: Some(String::from("tmp_default_dir.toml")),
+                    ..Default::default()
+                },
+            )
+            .context("starting attach proc")?;
+
+        let mut line_matcher = attach_proc.line_matcher()?;
+
+        attach_proc.run_cmd("pwd")?;
+        line_matcher.scan_until_re("tmp$")?;
+
+        Ok(())
+    })
+}
+
+#[test]
+#[timeout(30000)]
+fn cli_tmp_dir() -> anyhow::Result<()> {
+    support::dump_err(|| {
+        let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+            .context("starting daemon proc")?;
+        let mut attach_proc = daemon_proc
+            .attach("sh1", AttachArgs { dir: Some(String::from("/tmp")), ..Default::default() })
+            .context("starting attach proc")?;
+
+        let mut line_matcher = attach_proc.line_matcher()?;
+
+        attach_proc.run_cmd("pwd")?;
+        line_matcher.scan_until_re("tmp$")?;
+
+        Ok(())
+    })
+}
+
+#[test]
+#[timeout(30000)]
 fn version_mismatch_client_newer() -> anyhow::Result<()> {
     support::dump_err(|| {
         let mut daemon_proc = support::daemon::Proc::new(

--- a/shpool/tests/data/tmp_default_dir.toml
+++ b/shpool/tests/data/tmp_default_dir.toml
@@ -1,0 +1,10 @@
+norc = true
+noecho = true
+shell = "/bin/bash"
+session_restore_mode = "simple"
+prompt_prefix = ""
+default_dir = "/tmp"
+
+[env]
+PS1 = "prompt> "
+TERM = ""

--- a/shpool/tests/support/daemon.rs
+++ b/shpool/tests/support/daemon.rs
@@ -47,6 +47,7 @@ pub struct AttachArgs {
     pub extra_env: Vec<(String, String)>,
     pub ttl: Option<time::Duration>,
     pub cmd: Option<String>,
+    pub dir: Option<String>,
 }
 
 pub struct HooksRecorder {
@@ -310,6 +311,10 @@ impl Proc {
         if let Some(cmd_str) = &args.cmd {
             cmd.arg("-c");
             cmd.arg(cmd_str);
+        }
+        if let Some(dir) = &args.dir {
+            cmd.arg("--dir");
+            cmd.arg(dir);
         }
         let proc = cmd.arg(name).spawn().context(format!("spawning attach proc for {name}"))?;
 


### PR DESCRIPTION
This patch adds a new -d/--dir flag to allow you to spawn shells in the current directory (or any random directory) when you initially create the shell via `shpool attach`. Additionally, this patch adds a new configuration option in the config file to set a different default from your home directory.

Fixes #47

This also addresses half of #241