### PR TITLE
fix: hang when starting with nu shell

### DIFF
--- a/libshpool/src/consts.rs
+++ b/libshpool/src/consts.rs
@@ -33,8 +33,8 @@ pub const STARTUP_SENTINEL: &str = "SHPOOL_STARTUP_SENTINEL";
 pub const PROMPT_SENTINEL: &str = "SHPOOL_PROMPT_SETUP_SENTINEL";
 
 // A magic env var which indicates that a `shpool daemon` invocation should
-// actually just print the given sentinal then exit. We do this because
-// using `echo` will cause the sentinal value to appear multiple times
+// actually just print the given sentinel then exit. We do this because
+// using `echo` will cause the sentinel value to appear multiple times
 // in the output stream. For the same reason, we don't set the value
 // to an actual sentianl, but instead either "startup" or "prompt".
 pub const SENTINEL_FLAG_VAR: &str = "SHPOOL__INTERNAL__PRINT_SENTINEL";

--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -43,10 +43,6 @@ pub fn maybe_inject_prefix(
     prompt_prefix: &str,
     session_name: &str,
 ) -> anyhow::Result<()> {
-    if prompt_prefix.is_empty() {
-        return Ok(());
-    }
-
     let shell_pid = pty_master.child_pid().ok_or(anyhow!("no child pid"))?;
     // scan for the startup sentinel so we know it is safe to sniff the shell
     let mut pty_master = pty_master.is_parent().context("expected parent")?;
@@ -180,9 +176,9 @@ pub struct SentinelScanner {
 
 impl SentinelScanner {
     /// Create a new sentinel scanner.
-    pub fn new(sentinal: &str) -> Self {
+    pub fn new(sentinel: &str) -> Self {
         let mut scanner = Trie::new();
-        scanner.insert(sentinal.bytes(), ());
+        scanner.insert(sentinel.bytes(), ());
 
         SentinelScanner { scanner, cursor: TrieCursor::Start, num_matches: 0 }
     }

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -106,7 +106,7 @@ pub struct SessionInner {
     pub term_db: Arc<termini::TermInfo>,
     pub daily_messenger: Arc<show_motd::DailyMessenger>,
     pub needs_initial_motd_dump: bool,
-    pub custom_cmd: bool,
+    pub supports_sentinels: bool,
 
     /// The join handle for the always-on background shell->client thread.
     /// Only wrapped in an option so we can spawn the thread after
@@ -202,9 +202,7 @@ impl SessionInner {
 
         // We only scan for the prompt sentinel if the user has not set up a
         // custom command or blanked out the prompt_prefix config option.
-        let prompt_prefix_is_blank =
-            self.config.get().prompt_prefix.as_ref().map(|p| p.is_empty()).unwrap_or(false);
-        let mut has_seen_prompt_sentinel = self.custom_cmd || prompt_prefix_is_blank;
+        let mut has_seen_prompt_sentinel = !self.supports_sentinels;
 
         let daily_messenger = Arc::clone(&self.daily_messenger);
         let mut needs_initial_motd_dump = self.needs_initial_motd_dump;

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1122,6 +1122,7 @@ fn prompt_prefix_bash() -> anyhow::Result<()> {
         let mut stdout = child.stdout.take().context("missing stdout")?;
         let mut stdout_str = String::from("");
         stdout.read_to_string(&mut stdout_str).context("slurping stdout")?;
+        eprintln!("stdout_str: {}", stdout_str);
         let stdout_re = Regex::new(".*session_name=sh1 prompt>.*")?;
         assert!(stdout_re.is_match(&stdout_str));
 


### PR DESCRIPTION
This patch fixes a bug where shpool would hang when trying to start a nu shell by default. This has to do with our startup sentinal injection. A workaround exists where you can just blank out the prompt prefix, but we should try to automatically do that much when working with nu.

I should add a note to the troubleshooting wiki explaining this so that nu shell users don't get confused as to why shpool is not injecting a prompt automatically for them.

Fixes #269