### PR TITLE
Add Homebrew tap formula

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -16,7 +16,7 @@ jobs:
           formula-name: shpool
           formula-path: Formula/shpool.rb
           homebrew-tap: shell-pool/shpool
-          base-branch: main
+          base-branch: master
           download-url: https://github.com/shell-pool/shpool/archive/refs/tags/${{ github.ref_name }}.tar.gz
           commit-message: |
             Update Homebrew formula to {{version}}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -10,15 +10,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: actions/checkout@v4
         with:
-          formula-name: shpool
-          formula-path: Formula/shpool.rb
-          homebrew-tap: shell-pool/shpool
-          base-branch: master
-          download-url: https://github.com/shell-pool/shpool/archive/refs/tags/${{ github.ref_name }}.tar.gz
-          commit-message: |
-            Update Homebrew formula to {{version}}
+          ref: master
+
+      - name: Update formula version and SHA256
+        run: |
+          VERSION="${{ github.ref_name }}"
+          URL="https://github.com/shell-pool/shpool/archive/refs/tags/${VERSION}.tar.gz"
+          SHA256=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+
+          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/shpool.rb
+          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/shpool.rb
+
+      - name: Open PR
+        run: |
+          VERSION="${{ github.ref_name }}"
+          BRANCH="homebrew-formula-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Formula/shpool.rb
+          git commit -m "Update Homebrew formula to ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "Update Homebrew formula to ${VERSION}" \
+            --body "Automated update of \`Formula/shpool.rb\` for release ${VERSION}." \
+            --base master \
+            --head "$BRANCH"
         env:
-          COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,24 @@
+name: Update Homebrew formula
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: shpool
+          formula-path: Formula/shpool.rb
+          homebrew-tap: shell-pool/shpool
+          base-branch: main
+          download-url: https://github.com/shell-pool/shpool/archive/refs/tags/${{ github.ref_name }}.tar.gz
+          commit-message: |
+            Update Homebrew formula to {{version}}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Formula/shpool.rb
+++ b/Formula/shpool.rb
@@ -23,7 +23,6 @@ class Shpool < Formula
   end
 
   test do
-    # Daemon requires a TTY to function fully, so just verify the binary runs
-    assert_match version.to_s, shell_output("#{bin}/shpool --version")
+    assert_match version.to_s, shell_output("#{bin}/shpool version")
   end
 end

--- a/Formula/shpool.rb
+++ b/Formula/shpool.rb
@@ -1,0 +1,29 @@
+class Shpool < Formula
+  desc "Lightweight persistent shell session manager"
+  homepage "https://github.com/shell-pool/shpool"
+  url "https://github.com/shell-pool/shpool/archive/refs/tags/v0.9.5.tar.gz"
+  sha256 "cc958a1f66ed8c75892544c7921a764f0469233a0ca58b441249ed593bdcdaf0"
+  license "Apache-2.0"
+  head "https://github.com/shell-pool/shpool.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install",
+      "--locked",
+      "--root", prefix,
+      "--path", "shpool"
+  end
+
+  service do
+    run [opt_bin/"shpool", "daemon"]
+    keep_alive true
+    log_path var/"log/shpool.log"
+    error_log_path var/"log/shpool.log"
+  end
+
+  test do
+    # Daemon requires a TTY to function fully, so just verify the binary runs
+    assert_match version.to_s, shell_output("#{bin}/shpool --version")
+  end
+end

--- a/Formula/shpool.rb
+++ b/Formula/shpool.rb
@@ -4,7 +4,7 @@ class Shpool < Formula
   url "https://github.com/shell-pool/shpool/archive/refs/tags/v0.9.5.tar.gz"
   sha256 "cc958a1f66ed8c75892544c7921a764f0469233a0ca58b441249ed593bdcdaf0"
   license "Apache-2.0"
-  head "https://github.com/shell-pool/shpool.git", branch: "main"
+  head "https://github.com/shell-pool/shpool.git", branch: "master"
 
   depends_on "rust" => :build
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ with the `nodaemonize` config option and the `-d/-D` command line switches.
 
 ### Installing via Homebrew
 
-If you have [Homebrew](https://brew.sh) installed, you can install `shpool` using
-the project's own tap:
+If you have [Homebrew](https://brew.sh) installed, you can install `shpool`
+directly from this repository's tap:
 
 ```
-brew tap shell-pool/shpool
-brew install shpool
+brew tap shell-pool/shpool https://github.com/shell-pool/shpool
+brew install shell-pool/shpool/shpool
 ```
 
 To have the `shpool` daemon start automatically at login and restart if it
 crashes, you can register it as a service:
 
 ```
-brew services start shpool
+brew services start shell-pool/shpool/shpool
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ one is missing. Autodaemonization is enabled by default, so you don't
 need to do anything special to use it, though you can control its behavior
 with the `nodaemonize` config option and the `-d/-D` command line switches.
 
+### Installing via Homebrew
+
+If you have [Homebrew](https://brew.sh) installed, you can install `shpool` using
+the project's own tap:
+
+```
+brew tap shell-pool/shpool
+brew install shpool
+```
+
+To have the `shpool` daemon start automatically at login and restart if it
+crashes, you can register it as a service:
+
+```
+brew services start shpool
+```
+
 ## Usage
 
 Generally `shpool` is used to provide persistent sessions when

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Use the full path to the binary instead:
 
 ```
 Host = main edit
-    Hostname mac.example.com
+    Hostname remote.host.example.com
 
     RemoteCommand /opt/homebrew/bin/shpool attach -f %k
     RequestTTY yes

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ crashes, you can register it as a service:
 brew services start shell-pool/shpool/shpool
 ```
 
+> [!NOTE]
+> On macOS hosts, SSH connects using a non-login shell that does not source
+> your profile, so `shpool` may not be on `$PATH`. Use the full path to the
+> binary in your `RemoteCommand`. See [Connecting to a macOS host](#connecting-to-a-macos-host)
+> for a ready-to-use example.
+
 ## Usage
 
 Generally `shpool` is used to provide persistent sessions when
@@ -188,6 +194,23 @@ Host = main edit
 
 You can then attach to these sessions with `ssh main` or `ssh edit`.
 `%k` expands to the "host" named on the command line.
+
+##### Connecting to a macOS host
+
+SSH on macOS runs `RemoteCommand` in a non-login, non-interactive shell that
+does not source your shell profile, so `shpool` will not be found on `$PATH`.
+Use the full path to the binary instead:
+
+```
+Host = main edit
+    Hostname mac.example.com
+
+    RemoteCommand /opt/homebrew/bin/shpool attach -f %k
+    RequestTTY yes
+```
+
+If you installed `shpool` somewhere other than `/opt/homebrew/bin`, adjust the
+path accordingly (`which shpool` on the host will tell you).
 
 ##### shell function
 


### PR DESCRIPTION
## Summary

Adds a Homebrew tap so users can install `shpool` directly from this repository without a separate tap repo:

\`\`\`
brew tap shell-pool/shpool https://github.com/shell-pool/shpool
brew install shell-pool/shpool/shpool
\`\`\`

### Changes

- **`Formula/shpool.rb`** — formula targeting the `shpool` workspace member, with a `service` block for launchd integration on macOS (`brew services start`)
- **`.github/workflows/homebrew.yml`** — on each `v*` tag push, opens a PR updating the version and SHA256 in the formula automatically (no third-party actions, no direct push to master)
- **`README.md`** — adds a "Installing via Homebrew" section, a note about the macOS `$PATH` caveat with SSH, and a macOS-specific `~/.ssh/config` example using the full binary path

## Test plan

- [ ] `brew tap shell-pool/shpool https://github.com/shell-pool/shpool`
- [ ] `brew install shell-pool/shpool/shpool` builds and installs successfully
- [ ] `brew test shell-pool/shpool/shpool` passes (`shpool version` outputs the expected version)
- [ ] `brew services start shell-pool/shpool/shpool` registers the daemon with launchd