### PR TITLE
README: add Homebrew installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ one is missing. Autodaemonization is enabled by default, so you don't
 need to do anything special to use it, though you can control its behavior
 with the `nodaemonize` config option and the `-d/-D` command line switches.
 
+### Installing with Homebrew
+
+On macOS, `shpool` can be installed via the project's [Homebrew tap](https://github.com/shell-pool/homebrew-shpool):
+
+```
+brew tap shell-pool/shpool
+brew install shpool
+```
+
 ## Usage
 
 Generally `shpool` is used to provide persistent sessions when

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ brew tap shell-pool/shpool
 brew install shpool
 ```
 
+To have the daemon start automatically at login:
+
+```
+brew services start shpool
+```
+
 ## Usage
 
 Generally `shpool` is used to provide persistent sessions when


### PR DESCRIPTION
Adds a "Installing with Homebrew" section to the README, parallel to the existing "Installing from crates.io" section, pointing macOS users to the [homebrew-shpool](https://github.com/shell-pool/homebrew-shpool) tap.