### PR TITLE
chore: tweak AI policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Issue Link
+
+## AI Policy Ack
+
+Please ack that you have read the [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)
+and explain your use of AI to generate this PR.
+
+## Description

--- a/HACKING.md
+++ b/HACKING.md
@@ -14,6 +14,8 @@ and prevent the accumulation of bloat or needless abstraction. If you do use
 AI to generate code, you must review and test it carefully yourself. Do not
 send patches you don't understand.
 
+When creating PRs or filing issues, disclose your AI usage.
+
 ## Installing From Source
 
 ### Install a rust toolchain


### PR DESCRIPTION
I want a disclosure of AI use in pull requests, so let's add it to the AI policy. AI use is fine, but if a change is AI generated I'll need to review a bit more carefully.