### PR TITLE
fix: exe path resolution bug

### DIFF
--- a/libshpool/src/daemon/prompt.rs
+++ b/libshpool/src/daemon/prompt.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, instrument, warn};
 use crate::{
     consts::{SENTINEL_FLAG_VAR, STARTUP_SENTINEL},
     daemon::trie::{Trie, TrieCursor},
-    test_hooks,
+    exe, test_hooks,
 };
 
 // We don't need an agressive poll cadence because the normal case is
@@ -123,7 +123,7 @@ pub fn maybe_inject_prefix(
     // shells have subtly different echo behavior which makes it
     // hard to make the scanner work right.
     let exe_path =
-        std::env::current_exe().context("getting current exe path")?.to_string_lossy().into_owned();
+        exe::current().context("getting current exe path")?.to_string_lossy().into_owned();
     let sentinel_cmd = format!("\n {}=prompt {} daemon\n", SENTINEL_FLAG_VAR, exe_path);
     script.push_str(sentinel_cmd.as_str());
 
@@ -138,7 +138,7 @@ fn wait_for_startup(pty_master: &mut shpool_pty::fork::Master) -> anyhow::Result
     test_hooks::emit("wait-for-startup-enter");
     let mut startup_sentinel_scanner = SentinelScanner::new(STARTUP_SENTINEL);
     let exe_path =
-        std::env::current_exe().context("getting current exe path")?.to_string_lossy().into_owned();
+        exe::current().context("getting current exe path")?.to_string_lossy().into_owned();
     let startup_sentinel_cmd = format!("\n {}=startup {} daemon\n", SENTINEL_FLAG_VAR, exe_path);
 
     pty_master

--- a/libshpool/src/exe.rs
+++ b/libshpool/src/exe.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+/// The path of the current exe, without any funny business.
+pub fn current() -> anyhow::Result<PathBuf> {
+    let path = std::env::current_exe()?;
+
+    // The linux kernel will append " (deleted)" to the path that
+    // /proc/<pid>/exe links to when the binary file gets deleted.
+    // This happens on package update when a new version is copied
+    // into place, so we need to handle it. We'll just assume that
+    // the new file that replaced us is a new shpool version.
+    if cfg!(target_os = "linux") {
+        if let Some(path_str) = path.to_str() {
+            if let Some(stripped) = path_str.strip_suffix(" (deleted)") {
+                return Ok(PathBuf::from(stripped));
+            }
+        }
+    }
+
+    Ok(path)
+}

--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -36,6 +36,7 @@ mod daemon;
 mod daemonize;
 mod detach;
 mod duration;
+mod exe;
 mod hooks;
 mod kill;
 mod list;

--- a/shpool/tests/regression.rs
+++ b/shpool/tests/regression.rs
@@ -119,3 +119,66 @@ fn no_loop_on_shell_exit_during_startup() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Regression test for a bug where shpool would fail to spawn new shells
+/// if the binary was overwritten (as happens during package updates).
+/// When a binary is overwritten, `std::env::current_exe()` returns a path
+/// ending in " (deleted)". We need to strip this to correctly self-exec.
+#[test]
+#[timeout(30000)]
+fn replaced_binary_can_still_spawn_shells() -> anyhow::Result<()> {
+    let tmp_dir = tmpdir::Dir::new("/tmp/shpool-test")?;
+    let bin_dir = tmp_dir.path().join("bin");
+    fs::create_dir_all(&bin_dir)?;
+    let shpool_bin_orig = support::shpool_bin()?;
+    let shpool_bin_path = bin_dir.join("shpool");
+
+    let copy_bin = |src_path: &std::path::Path, dst_path: &std::path::Path| -> anyhow::Result<()> {
+        let mut src = fs::File::open(src_path)?;
+        let mut dst = fs::File::create(dst_path)?;
+        std::io::copy(&mut src, &mut dst)?;
+        dst.sync_all()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = dst.metadata()?.permissions();
+            perms.set_mode(0o755);
+            dst.set_permissions(perms)?;
+        }
+        Ok(())
+    };
+
+    copy_bin(&shpool_bin_orig, &shpool_bin_path)?;
+    std::thread::sleep(Duration::from_millis(200));
+
+    let config_file = support::testdata_file("prompt_prefix_bash.toml");
+
+    let daemon_args =
+        DaemonArgs { bin_path: Some(shpool_bin_path.clone()), ..DaemonArgs::default() };
+    let mut daemon_proc =
+        support::daemon::Proc::new(&config_file, daemon_args).context("starting daemon proc")?;
+
+    // First attach should work fine.
+    let _attach_proc1 =
+        daemon_proc.attach("sh1", Default::default()).context("starting first attach proc")?;
+    daemon_proc.await_event("wait-for-startup-enter")?;
+    // Give it a moment to finish startup
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Remove the binary and restore it.
+    // This simulates a package update where the old binary is unlinked
+    // and a new one is put in its place.
+    fs::remove_file(&shpool_bin_path)?;
+    copy_bin(&shpool_bin_orig, &shpool_bin_path)?;
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Second attach should also work.
+    // On BUGGY code: this fails because the daemon tries to exec ".../shpool
+    // (deleted) daemon" which does not exist.
+    let _attach_proc2 =
+        daemon_proc.attach("sh2", Default::default()).context("starting second attach proc")?;
+    daemon_proc.await_event("wait-for-startup-enter")?;
+    daemon_proc.await_event("daemon-bidi-stream-enter")?;
+
+    Ok(())
+}

--- a/shpool/tests/support/daemon.rs
+++ b/shpool/tests/support/daemon.rs
@@ -26,6 +26,7 @@ pub struct Proc {
     pub events: Option<Events>,
     pub socket_path: PathBuf,
     config_path: PathBuf,
+    bin_path: PathBuf,
     // Only present when created by new_instrumented()
     pub hook_records: Option<Arc<Mutex<HookRecords>>>,
 }
@@ -34,11 +35,12 @@ pub struct DaemonArgs {
     pub listen_events: bool,
     pub extra_env: Vec<(String, String)>,
     pub verbosity: i64,
+    pub bin_path: Option<PathBuf>,
 }
 
 impl std::default::Default for DaemonArgs {
     fn default() -> Self {
-        DaemonArgs { listen_events: true, extra_env: vec![], verbosity: 2 }
+        DaemonArgs { listen_events: true, extra_env: vec![], verbosity: 2, bin_path: None }
     }
 }
 
@@ -106,6 +108,7 @@ pub struct HookRecords {
 
 impl Proc {
     pub fn new<P: AsRef<Path>>(config: P, args: DaemonArgs) -> anyhow::Result<Proc> {
+        let bin = args.bin_path.clone().unwrap_or_else(|| shpool_bin().unwrap());
         let tmp_dir = tmpdir::Dir::new("/tmp/shpool-test")?;
 
         let socket_path = tmp_dir.path().join("shpool.socket");
@@ -120,7 +123,7 @@ impl Proc {
             testdata_file(config)
         };
 
-        let mut cmd = Command::new(shpool_bin()?);
+        let mut cmd = Command::new(&bin);
         cmd.stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .arg("--log-file")
@@ -168,6 +171,7 @@ impl Proc {
             events,
             socket_path,
             config_path: resolved_config,
+            bin_path: bin,
             hook_records: None,
         })
     }
@@ -258,6 +262,7 @@ impl Proc {
             events: None,
             socket_path,
             config_path: resolved_config,
+            bin_path: shpool_bin()?,
             hook_records: Some(hook_records),
         })
     }
@@ -286,7 +291,7 @@ impl Proc {
         eprintln!("spawning attach proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        let mut cmd = Command::new(shpool_bin()?);
+        let mut cmd = Command::new(&self.bin_path);
         cmd.stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(if args.null_stdin { Stdio::null() } else { Stdio::piped() })
@@ -347,7 +352,7 @@ impl Proc {
         eprintln!("spawning detach proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        let mut cmd = Command::new(shpool_bin()?);
+        let mut cmd = Command::new(&self.bin_path);
         cmd.arg("-vv")
             .arg("--log-file")
             .arg(&log_file)
@@ -366,7 +371,7 @@ impl Proc {
         eprintln!("spawning kill proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        let mut cmd = Command::new(shpool_bin()?);
+        let mut cmd = Command::new(&self.bin_path);
         cmd.arg("-vv")
             .arg("--log-file")
             .arg(&log_file)
@@ -403,7 +408,7 @@ impl Proc {
         eprintln!("spawning list proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        Command::new(shpool_bin()?)
+        Command::new(&self.bin_path)
             .arg("-vv")
             .arg("--log-file")
             .arg(&log_file)
@@ -419,7 +424,7 @@ impl Proc {
         eprintln!("spawning list --json proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        Command::new(shpool_bin()?)
+        Command::new(&self.bin_path)
             .arg("-vv")
             .arg("--log-file")
             .arg(&log_file)
@@ -438,7 +443,7 @@ impl Proc {
         eprintln!("spawning set-log-level proc with log {:?}", &log_file);
         self.subproc_counter += 1;
 
-        Command::new(shpool_bin()?)
+        Command::new(&self.bin_path)
             .arg("-vv")
             .arg("--log-file")
             .arg(&log_file)


### PR DESCRIPTION
## Issue Link

n/a I just hit this myself and spotted it in the logs. There is a google internal bug that's pretty useless on a public issue tracker that I think is relevant.

## AI Policy Ack

ack

### This PR was:

* [ ] mostly or completely vibe coded
* [ ] mostly or completely meat coded
* [X] bit of both

I meat coded the fix and vibed the test.

## Description

When the shpool daemon binary gets overwritten, linux will start appending ' (deleted)' to the exe path. This causes problems when we self-exec. This has started happening to me pretty regularly and I think it is because of package updates silently overwriting the binary with a new version under the hood.

I think this is the underlying cause that caused the bug I fixed in #348.

This bug was introduced when we did the mac port (in 703096692).