### PR TITLE
feat: add var_default config option

### DIFF
--- a/libshpool/src/config.rs
+++ b/libshpool/src/config.rs
@@ -293,6 +293,12 @@ pub struct Config {
     /// See https://man7.org/linux/man-pages/man8/pam_motd.8.html
     /// for more info.
     pub motd_args: Option<Vec<String>>,
+
+    /// A list of default values for variables. Setting values
+    /// in this list is equivilant to running `shpool var set` for
+    /// each (var, value) tuple every time the shpool daemon starts
+    /// up.
+    pub var_default: Option<Vec<VarSetting>>,
 }
 
 impl Config {
@@ -327,6 +333,7 @@ impl Config {
             prompt_prefix: self.prompt_prefix.or(another.prompt_prefix),
             motd: self.motd.or(another.motd),
             motd_args: self.motd_args.or(another.motd_args),
+            var_default: self.var_default.or(another.var_default),
         }
     }
 }
@@ -407,6 +414,14 @@ pub enum MotdDisplayMode {
     Dump,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct VarSetting {
+    /// The variable name.
+    pub var: String,
+    /// The variable value.
+    pub value: String,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -435,6 +450,11 @@ mod test {
             "#,
             r#"
             session_restore_engine = "vterm"
+            "#,
+            r#"
+            [[var_default]]
+            var = "foo"
+            value = "bar"
             "#,
         ];
 

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -111,6 +111,17 @@ impl Server {
             }
         });
 
+        let vars = Mutex::new(
+            config
+                .get()
+                .var_default
+                .clone()
+                .unwrap_or(vec![])
+                .into_iter()
+                .map(|v| (v.var, v.value))
+                .collect(),
+        );
+
         let daily_messenger = Arc::new(show_motd::DailyMessenger::new(config.clone())?);
         Ok(Arc::new(Server {
             config,
@@ -121,7 +132,7 @@ impl Server {
             events_bus,
             daily_messenger,
             log_level_handle,
-            vars: HashMap::new().into(),
+            vars,
         }))
     }
 

--- a/shpool/tests/data/var_default.toml
+++ b/shpool/tests/data/var_default.toml
@@ -1,0 +1,13 @@
+norc = true
+noecho = true
+shell = "/bin/bash"
+session_restore_mode = "simple"
+prompt_prefix = ""
+
+[env]
+PS1 = "prompt> "
+TERM = ""
+
+[[var_default]]
+var = "default_foo"
+value = "default_bar"

--- a/shpool/tests/support/line_matcher.rs
+++ b/shpool/tests/support/line_matcher.rs
@@ -31,8 +31,8 @@ where
     pub fn scan_until_re(&mut self, re: &str) -> anyhow::Result<()> {
         let compiled_re = Regex::new(re)?;
         let start = time::Instant::now();
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
             match self.out.read_line(&mut line) {
                 Ok(0) => {
                     return Err(anyhow!("LineMatcher: EOF"));
@@ -67,6 +67,7 @@ where
                 return Ok(());
             } else {
                 eprintln!(" no match");
+                line.clear();
             }
         }
     }
@@ -80,8 +81,8 @@ where
 
     pub fn capture_re(&mut self, re: &str) -> anyhow::Result<Vec<Option<String>>> {
         let start = time::Instant::now();
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
             match self.out.read_line(&mut line) {
                 Ok(0) => {
                     return Err(anyhow!("LineMatcher: EOF"));
@@ -127,8 +128,8 @@ where
     /// assertions fail (the never match regex).
     pub fn drain(&mut self) -> anyhow::Result<()> {
         let start = time::Instant::now();
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
             match self.out.read_line(&mut line) {
                 Ok(0) => {
                     return Ok(());
@@ -156,6 +157,7 @@ where
             }
 
             self.check_persistant_assertions(&line)?;
+            line.clear();
         }
     }
 

--- a/shpool/tests/var.rs
+++ b/shpool/tests/var.rs
@@ -135,3 +135,21 @@ fn no_daemon() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[timeout(30000)]
+fn default_vars() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new(
+        "var_default.toml",
+        DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+    )
+    .context("starting daemon proc")?;
+
+    let out = daemon_proc.var_get("default_foo")?;
+    assert!(out.status.success(), "var get proc did not exit successfully");
+
+    let stdout = String::from_utf8_lossy(&out.stdout[..]);
+    assert_eq!(stdout.trim(), "default_bar");
+
+    Ok(())
+}


### PR DESCRIPTION
## Issue Link

n/a

## AI Policy Ack

Ack

### This PR was:

* [ ] mostly or completely vibe coded
* [ ] mostly or completely meat coded
* [X] bit of both

I vibed the test.

## Description

This patch adds a new var_default config option allowing users to set initial values for variables on daemon startup.

I want this because I want to be able to set a default workspace var so I can know that it is always safe to connect to `{workspace}-edit` and not have to worry about the daemon being in a state where workspace is not yet set. This is possible to hack together today with a series of `shpool var get` and `shpool var set` commands in a wrapper script, but I want it as a first-party feature.
