### PR TITLE
Put `events` subcommand help in alphabetical order

### DIFF
--- a/libshpool/src/lib.rs
+++ b/libshpool/src/lib.rs
@@ -207,6 +207,14 @@ environment.")]
         sessions: Vec<String>,
     },
 
+    #[clap(about = "Subscribe to the daemon's push-event stream
+
+Connects to the events socket and writes each event (one JSON object
+per line) to stdout, flushing after every line so the stream is
+pipeline-friendly (e.g. `shpool events | jq`). See EVENTS.md for
+details.")]
+    Events,
+
     #[clap(about = "Kill the given sessions
 
 This detaches the session if it is attached and kills the underlying
@@ -255,14 +263,6 @@ you could just do `shpool var set workspace key-bugfix`.
         #[clap(subcommand)]
         command: VarCommands,
     },
-
-    #[clap(about = "Subscribe to the daemon's push-event stream
-
-Connects to the events socket and writes each event (one JSON object
-per line) to stdout, flushing after every line so the stream is
-pipeline-friendly (e.g. `shpool events | jq`). See EVENTS.md for
-details.")]
-    Events,
 }
 
 /// The subcommds of the var command.


### PR DESCRIPTION
## Issue Link

None

## AI Policy Ack

`ACK`

### This PR was:

* [ ] mostly or completely vibe coded
* [x] mostly or completely meat coded
* [ ] bit of both

## Description

Follow-up from https://github.com/shell-pool/shpool/pull/352
The help for the `events` subcommand wasn't in alphabetical order, so this just fixes that.