### PR TITLE
feat: report attachments in shpool list --json

### DIFF
--- a/libshpool/src/attach.rs
+++ b/libshpool/src/attach.rs
@@ -286,6 +286,7 @@ impl Attach {
                 cmd: resolved.cmd.clone(),
                 dir: start_dir,
                 start_cmd: resolved.start_cmd.clone(),
+                name_template: self.tmpls.session_name.source().to_string(),
             }))
             .context("writing attach header")?;
 

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -206,15 +206,18 @@ impl Server {
 
         let header = parse_connect_header(&mut stream).context("parsing connect header")?;
 
-        if let Err(err) = check_peer(&stream) {
-            if let ConnectHeader::Attach(_) = header {
-                write_reply(
-                    &mut stream,
-                    AttachReplyHeader { status: AttachStatus::Forbidden(format!("{err:?}")) },
-                )?;
+        let peer_pid = match check_peer(&stream) {
+            Ok(peer_pid) => peer_pid,
+            Err(err) => {
+                if let ConnectHeader::Attach(_) = header {
+                    write_reply(
+                        &mut stream,
+                        AttachReplyHeader { status: AttachStatus::Forbidden(format!("{err:?}")) },
+                    )?;
+                }
+                stream.shutdown(net::Shutdown::Both).context("closing stream")?;
+                return Err(err);
             }
-            stream.shutdown(net::Shutdown::Both).context("closing stream")?;
-            return Err(err);
         };
 
         // Unset the read timeout before we pass things off to a
@@ -224,7 +227,7 @@ impl Server {
         stream.set_read_timeout(None).context("unsetting read timout on inbound session")?;
 
         match header {
-            ConnectHeader::Attach(h) => self.handle_attach(stream, conn_id, h),
+            ConnectHeader::Attach(h) => self.handle_attach(stream, conn_id, h, peer_pid),
             ConnectHeader::Detach(r) => self.handle_detach(stream, r),
             ConnectHeader::Kill(r) => self.handle_kill(stream, r),
             ConnectHeader::List => self.handle_list(stream),
@@ -241,6 +244,7 @@ impl Server {
         mut stream: UnixStream,
         conn_id: usize,
         header: AttachHeader,
+        peer_pid: libc::pid_t,
     ) -> anyhow::Result<()> {
         if header.name.chars().any(|c| '/' == c || c.is_whitespace())
             || header.name == "."
@@ -263,19 +267,20 @@ impl Server {
         let shell_env = self.build_shell_env(&user_info, &header).context("building shell env")?;
 
         test_hooks::emit("handle-attach-before-select-shell");
-        let (shell_results, status) =
-            match self.select_shell_desc(stream, conn_id, &header, &user_info, &shell_env) {
-                Ok(t) => t,
-                Err(err)
-                    if err
-                        .downcast_ref::<ShellSelectionError>()
-                        .map(|e| e == &ShellSelectionError::BusyShellSession)
-                        .unwrap_or(false) =>
-                {
-                    return Ok(());
-                }
-                Err(err) => return Err(err)?,
-            };
+        let (shell_results, status) = match self
+            .select_shell_desc(stream, conn_id, &header, &user_info, &shell_env, peer_pid)
+        {
+            Ok(t) => t,
+            Err(err)
+                if err
+                    .downcast_ref::<ShellSelectionError>()
+                    .map(|e| e == &ShellSelectionError::BusyShellSession)
+                    .unwrap_or(false) =>
+            {
+                return Ok(());
+            }
+            Err(err) => return Err(err)?,
+        };
 
         self.link_ssh_auth_sock(&header).context("linking SSH_AUTH_SOCK")?;
         self.populate_session_env_file(&header).context("populating session env file")?;
@@ -401,6 +406,7 @@ impl Server {
         header: &AttachHeader,
         user_info: &user::Info,
         shell_env: &[(OsString, OsString)],
+        peer_pid: libc::pid_t,
     ) -> anyhow::Result<(
         Option<(
             Arc<ExitNotifier>,
@@ -410,8 +416,6 @@ impl Server {
         AttachStatus,
     )> {
         let warnings = vec![];
-
-        let peer_pid = peer_pid(&stream)?;
 
         // Critical section for the global shells lock. We only hold it
         // while grubbing about for an existing session, then release it
@@ -1333,11 +1337,12 @@ where
     Ok(())
 }
 
-/// check_peer makes sure that a process dialing in on the shpool
-/// control socket has the same UID as the current user and that
-/// both have the same executable path.
+/// check_peer makes sure that a process dialing in on the shpool control socket
+/// has the same UID as the current user and that both have the same executable
+/// path. Returns the peer's pid, which the kernel captures at connect time and
+/// keeps fixed for the life of the connection.
 #[cfg(target_os = "linux")]
-fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
+fn check_peer(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
     use nix::sys::socket;
 
     let peer_creds = socket::getsockopt(sock, socket::sockopt::PeerCredentials)
@@ -1356,11 +1361,11 @@ fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
         warn!("attach binary differs from daemon binary");
     }
 
-    Ok(())
+    Ok(peer_creds.pid())
 }
 
 #[cfg(target_os = "macos")]
-fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
+fn check_peer(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
     use std::os::unix::io::AsRawFd;
 
     let mut peer_uid: libc::uid_t = 0;
@@ -1380,34 +1385,7 @@ fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
         return Err(anyhow!("shpool prohibits connections across users"));
     }
 
-    let peer_pid = unistd::Pid::from_raw(peer_pid(sock)?);
-    let self_pid = unistd::Pid::this();
-    let peer_exe = exe_for_pid(peer_pid).context("could not resolve exe from the pid")?;
-    let self_exe = exe_for_pid(self_pid).context("could not resolve our own exe")?;
-    if peer_exe != self_exe {
-        warn!("attach binary differs from daemon binary");
-    }
-
-    Ok(())
-}
-
-/// Read the pid of the process on the other end of the socket. Peer credentials
-/// are captured by the kernel at connect time and stay fixed for the life of
-/// the connection, so the result is stable across repeated calls.
-#[cfg(target_os = "linux")]
-fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
-    use nix::sys::socket;
-
-    let peer_creds = socket::getsockopt(sock, socket::sockopt::PeerCredentials)
-        .context("could not get peer creds from socket")?;
-    Ok(peer_creds.pid())
-}
-
-#[cfg(target_os = "macos")]
-fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
-    use std::os::unix::io::AsRawFd;
-
-    let mut pid: libc::pid_t = 0;
+    let mut peer_pid: libc::pid_t = 0;
     let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
     // Safety: getsockopt is standard POSIX FFI, all pointers and sizes are valid
     unsafe {
@@ -1415,7 +1393,7 @@ fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
             sock.as_raw_fd(),
             libc::SOL_LOCAL,
             libc::LOCAL_PEERPID,
-            &mut pid as *mut _ as *mut libc::c_void,
+            &mut peer_pid as *mut _ as *mut libc::c_void,
             &mut len,
         ) != 0
         {
@@ -1425,7 +1403,16 @@ fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
             ));
         }
     }
-    Ok(pid)
+
+    let self_pid = unistd::Pid::this();
+    let peer_exe = exe_for_pid(unistd::Pid::from_raw(peer_pid))
+        .context("could not resolve exe from the pid")?;
+    let self_exe = exe_for_pid(self_pid).context("could not resolve our own exe")?;
+    if peer_exe != self_exe {
+        warn!("attach binary differs from daemon binary");
+    }
+
+    Ok(peer_pid)
 }
 
 #[cfg(target_os = "linux")]

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -379,9 +379,7 @@ impl Server {
                     let _s = span!(Level::INFO, "disconnect_lock(shells)").entered();
                     let shells = self.shells.lock();
                     if let Some(session) = shells.get(&header.name) {
-                        session.lifecycle_timestamps.lock().last_disconnected_at =
-                            Some(time::SystemTime::now());
-                        *session.attachment.lock() = None;
+                        session.lifecycle.record_detached();
                         self.events_bus.publish(&events::Event::SessionDetached);
                     }
                 }
@@ -446,9 +444,7 @@ impl Server {
                             // the channel is still open so the subshell is still running
                             info!("taking over existing session inner");
                             inner.client_stream = Some(stream.try_clone()?);
-                            session.lifecycle_timestamps.lock().last_connected_at =
-                                Some(time::SystemTime::now());
-                            *session.attachment.lock() = Some(Attachment {
+                            session.lifecycle.record_attached(Attachment {
                                 session_name_template: header.name_template.clone(),
                                 pid: peer_pid,
                             });
@@ -536,9 +532,10 @@ impl Server {
             matches!(motd, MotdDisplayMode::Dump),
         )?;
 
-        session.lifecycle_timestamps.lock().last_connected_at = Some(time::SystemTime::now());
-        *session.attachment.lock() =
-            Some(Attachment { session_name_template: header.name_template.clone(), pid: peer_pid });
+        session.lifecycle.record_attached(Attachment {
+            session_name_template: header.name_template.clone(),
+            pid: peer_pid,
+        });
         {
             let _s = span!(Level::INFO, "select_shell_lock_2(shells)").entered();
             let mut shells = self.shells.lock();
@@ -647,13 +644,10 @@ impl Server {
                     if let shell::ClientConnectionStatus::DetachNone = status {
                         not_attached_sessions.push(session);
                     } else {
-                        // The bidi-loop unwind in handle_attach owns the
-                        // SessionDetached publish; we just update
-                        // last_disconnected_at eagerly so a concurrent list()
+                        // The bidi-loop unwind in handle_attach owns the SessionDetached publish;
+                        // we just update the lifecycle state eagerly so a concurrent list()
                         // reflects the detach immediately.
-                        s.lifecycle_timestamps.lock().last_disconnected_at =
-                            Some(time::SystemTime::now());
-                        *s.attachment.lock() = None;
+                        s.lifecycle.record_detached();
                     }
                 } else {
                     not_found_sessions.push(session);
@@ -786,12 +780,12 @@ impl Server {
                     None => SessionStatus::Attached,
                 };
 
-                let timestamps = v.lifecycle_timestamps.lock();
-                let last_connected_at_unix_ms = timestamps
+                let lifecycle_state = v.lifecycle.snapshot();
+                let last_connected_at_unix_ms = lifecycle_state
                     .last_connected_at
                     .map(|t| t.duration_since(time::UNIX_EPOCH).map(|d| d.as_millis() as i64))
                     .transpose()?;
-                let last_disconnected_at_unix_ms = timestamps
+                let last_disconnected_at_unix_ms = lifecycle_state
                     .last_disconnected_at
                     .map(|t| t.duration_since(time::UNIX_EPOCH).map(|d| d.as_millis() as i64))
                     .transpose()?;
@@ -803,7 +797,7 @@ impl Server {
                     last_connected_at_unix_ms,
                     last_disconnected_at_unix_ms,
                     status,
-                    attachments: v.attachment.lock().iter().cloned().collect(),
+                    attachments: lifecycle_state.attachment.into_iter().collect(),
                 })
             })
             .collect();
@@ -1181,8 +1175,7 @@ impl Server {
             child_pid,
             child_exit_notifier,
             started_at: time::SystemTime::now(),
-            lifecycle_timestamps: Mutex::new(shell::SessionLifecycleTimestamps::default()),
-            attachment: Mutex::new(None),
+            lifecycle: shell::SessionLifecycle::default(),
             inner: Arc::new(Mutex::new(session_inner)),
         })
     }

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -35,11 +35,11 @@ use anyhow::{anyhow, Context};
 use nix::unistd;
 use parking_lot::{ArcMutexGuard, Mutex, RawMutex};
 use shpool_protocol::{
-    AttachHeader, AttachReplyHeader, AttachStatus, ConnectHeader, DetachReply, DetachRequest,
-    KillReply, KillRequest, ListReply, LogLevel, MaybeSwitch, ModifyVarReply, ModifyVarRequest,
-    ResizeReply, Session, SessionMessageDetachReply, SessionMessageReply, SessionMessageRequest,
-    SessionMessageRequestPayload, SessionStatus, SetLogLevelReply, SetLogLevelRequest,
-    VersionHeader,
+    AttachHeader, AttachReplyHeader, AttachStatus, Attachment, ConnectHeader, DetachReply,
+    DetachRequest, KillReply, KillRequest, ListReply, LogLevel, MaybeSwitch, ModifyVarReply,
+    ModifyVarRequest, ResizeReply, Session, SessionMessageDetachReply, SessionMessageReply,
+    SessionMessageRequest, SessionMessageRequestPayload, SessionStatus, SetLogLevelReply,
+    SetLogLevelRequest, VersionHeader,
 };
 use tracing::{debug, error, info, instrument, span, warn, Level};
 
@@ -376,6 +376,7 @@ impl Server {
                     if let Some(session) = shells.get(&header.name) {
                         session.lifecycle_timestamps.lock().last_disconnected_at =
                             Some(time::SystemTime::now());
+                        *session.attachment.lock() = None;
                         self.events_bus.publish(&events::Event::SessionDetached);
                     }
                 }
@@ -410,6 +411,8 @@ impl Server {
     )> {
         let warnings = vec![];
 
+        let peer_pid = peer_pid(&stream)?;
+
         // Critical section for the global shells lock. We only hold it
         // while grubbing about for an existing session, then release it
         // so that we do not hold it during shell startup, which might
@@ -441,6 +444,10 @@ impl Server {
                             inner.client_stream = Some(stream.try_clone()?);
                             session.lifecycle_timestamps.lock().last_connected_at =
                                 Some(time::SystemTime::now());
+                            *session.attachment.lock() = Some(Attachment {
+                                template: header.name_template.clone(),
+                                pid: peer_pid,
+                            });
 
                             if inner
                                 .shell_to_client_join_h
@@ -526,6 +533,8 @@ impl Server {
         )?;
 
         session.lifecycle_timestamps.lock().last_connected_at = Some(time::SystemTime::now());
+        *session.attachment.lock() =
+            Some(Attachment { template: header.name_template.clone(), pid: peer_pid });
         {
             let _s = span!(Level::INFO, "select_shell_lock_2(shells)").entered();
             let mut shells = self.shells.lock();
@@ -640,6 +649,7 @@ impl Server {
                         // reflects the detach immediately.
                         s.lifecycle_timestamps.lock().last_disconnected_at =
                             Some(time::SystemTime::now());
+                        *s.attachment.lock() = None;
                     }
                 } else {
                     not_found_sessions.push(session);
@@ -789,6 +799,7 @@ impl Server {
                     last_connected_at_unix_ms,
                     last_disconnected_at_unix_ms,
                     status,
+                    attachments: v.attachment.lock().iter().cloned().collect(),
                 })
             })
             .collect();
@@ -890,7 +901,7 @@ impl Server {
         }
     }
 
-    /// Spawn a subshell and return the sessession descriptor for it. The
+    /// Spawn a subshell and return the session descriptor for it. The
     /// session is wrapped in an Arc so the inner session can hold a Weak
     /// back-reference to the session.
     #[instrument(skip_all)]
@@ -1167,6 +1178,7 @@ impl Server {
             child_exit_notifier,
             started_at: time::SystemTime::now(),
             lifecycle_timestamps: Mutex::new(shell::SessionLifecycleTimestamps::default()),
+            attachment: Mutex::new(None),
             inner: Arc::new(Mutex::new(session_inner)),
         })
     }
@@ -1368,7 +1380,34 @@ fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
         return Err(anyhow!("shpool prohibits connections across users"));
     }
 
-    let mut peer_pid: libc::pid_t = 0;
+    let peer_pid = unistd::Pid::from_raw(peer_pid(sock)?);
+    let self_pid = unistd::Pid::this();
+    let peer_exe = exe_for_pid(peer_pid).context("could not resolve exe from the pid")?;
+    let self_exe = exe_for_pid(self_pid).context("could not resolve our own exe")?;
+    if peer_exe != self_exe {
+        warn!("attach binary differs from daemon binary");
+    }
+
+    Ok(())
+}
+
+/// Read the pid of the process on the other end of the socket. Peer credentials
+/// are captured by the kernel at connect time and stay fixed for the life of
+/// the connection, so the result is stable across repeated calls.
+#[cfg(target_os = "linux")]
+fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
+    use nix::sys::socket;
+
+    let peer_creds = socket::getsockopt(sock, socket::sockopt::PeerCredentials)
+        .context("could not get peer creds from socket")?;
+    Ok(peer_creds.pid())
+}
+
+#[cfg(target_os = "macos")]
+fn peer_pid(sock: &UnixStream) -> anyhow::Result<libc::pid_t> {
+    use std::os::unix::io::AsRawFd;
+
+    let mut pid: libc::pid_t = 0;
     let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
     // Safety: getsockopt is standard POSIX FFI, all pointers and sizes are valid
     unsafe {
@@ -1376,7 +1415,7 @@ fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
             sock.as_raw_fd(),
             libc::SOL_LOCAL,
             libc::LOCAL_PEERPID,
-            &mut peer_pid as *mut _ as *mut libc::c_void,
+            &mut pid as *mut _ as *mut libc::c_void,
             &mut len,
         ) != 0
         {
@@ -1386,16 +1425,7 @@ fn check_peer(sock: &UnixStream) -> anyhow::Result<()> {
             ));
         }
     }
-
-    let peer_pid = unistd::Pid::from_raw(peer_pid);
-    let self_pid = unistd::Pid::this();
-    let peer_exe = exe_for_pid(peer_pid).context("could not resolve exe from the pid")?;
-    let self_exe = exe_for_pid(self_pid).context("could not resolve our own exe")?;
-    if peer_exe != self_exe {
-        warn!("attach binary differs from daemon binary");
-    }
-
-    Ok(())
+    Ok(pid)
 }
 
 #[cfg(target_os = "linux")]

--- a/libshpool/src/daemon/server.rs
+++ b/libshpool/src/daemon/server.rs
@@ -445,7 +445,7 @@ impl Server {
                             session.lifecycle_timestamps.lock().last_connected_at =
                                 Some(time::SystemTime::now());
                             *session.attachment.lock() = Some(Attachment {
-                                template: header.name_template.clone(),
+                                session_name_template: header.name_template.clone(),
                                 pid: peer_pid,
                             });
 
@@ -534,7 +534,7 @@ impl Server {
 
         session.lifecycle_timestamps.lock().last_connected_at = Some(time::SystemTime::now());
         *session.attachment.lock() =
-            Some(Attachment { template: header.name_template.clone(), pid: peer_pid });
+            Some(Attachment { session_name_template: header.name_template.clone(), pid: peer_pid });
         {
             let _s = span!(Level::INFO, "select_shell_lock_2(shells)").entered();
             let mut shells = self.shells.lock();

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -29,7 +29,7 @@ use std::{
 use anyhow::{anyhow, Context};
 use nix::{poll, poll::PollFlags, sys::signal, unistd::Pid};
 use parking_lot::Mutex;
-use shpool_protocol::{Chunk, ChunkKind, MaybeSwitch, TtySize};
+use shpool_protocol::{Attachment, Chunk, ChunkKind, MaybeSwitch, TtySize};
 use tracing::{debug, error, info, instrument, span, trace, warn, Level};
 
 use crate::{
@@ -76,6 +76,12 @@ pub struct SessionLifecycleTimestamps {
 pub struct Session {
     pub started_at: time::SystemTime,
     pub lifecycle_timestamps: Mutex<SessionLifecycleTimestamps>,
+    /// This session's attachment, if any. An `Option` here, but reported by
+    /// `handle_list` as a list so the wire can grow to multiple attachments
+    /// without a breaking change. Kept in its own lock rather than in `inner`
+    /// because a client holds `inner` while attached, which would otherwise
+    /// prevent `handle_list` from reading it while a client is attached.
+    pub attachment: Mutex<Option<Attachment>>,
     pub child_pid: libc::pid_t,
     pub child_exit_notifier: Arc<ExitNotifier>,
     pub shell_to_client_ctl: Arc<Mutex<ShellToClientCtl>>,

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -63,25 +63,54 @@ const SHELL_TO_CLIENT_POLL_MS: u16 = 50;
 // shell->client thread.
 const SHELL_TO_CLIENT_CTL_TIMEOUT: time::Duration = time::Duration::from_millis(300);
 
-/// Timestamps tracking when sessions were last connected/disconnected.
-/// Combined behind a single lock to avoid taking multiple locks.
+/// Lifecycle state tracking when sessions were last connected/disconnected and
+/// by whom. The fields update in lockstep, so they live behind a single private
+/// lock that only this type's methods take, exactly once per update or read.
 #[derive(Debug, Default)]
-pub struct SessionLifecycleTimestamps {
+pub struct SessionLifecycle {
+    state: Mutex<SessionLifecycleState>,
+}
+
+impl SessionLifecycle {
+    /// Record a client attaching to the session.
+    pub fn record_attached(&self, attachment: Attachment) {
+        let mut state = self.state.lock();
+        state.last_connected_at = Some(time::SystemTime::now());
+        state.attachment = Some(attachment);
+    }
+
+    /// Record the attached client going away.
+    pub fn record_detached(&self) {
+        let mut state = self.state.lock();
+        state.last_disconnected_at = Some(time::SystemTime::now());
+        state.attachment = None;
+    }
+
+    /// Return a copy of the current lifecycle state.
+    pub fn snapshot(&self) -> SessionLifecycleState {
+        self.state.lock().clone()
+    }
+}
+
+/// A session's lifecycle data, handed out by value via
+/// [`SessionLifecycle::snapshot`].
+#[derive(Clone, Debug, Default)]
+pub struct SessionLifecycleState {
     pub last_connected_at: Option<time::SystemTime>,
     pub last_disconnected_at: Option<time::SystemTime>,
+    /// This session's attachment, if any. An `Option` here, but reported by
+    /// `handle_list` as a list so the wire can grow to multiple attachments
+    /// without a breaking change. Kept here rather than in `inner` because a
+    /// client holds `inner` while attached, which would otherwise prevent
+    /// `handle_list` from reading it while a client is attached.
+    pub attachment: Option<Attachment>,
 }
 
 /// Session represent a shell session
 #[derive(Debug)]
 pub struct Session {
     pub started_at: time::SystemTime,
-    pub lifecycle_timestamps: Mutex<SessionLifecycleTimestamps>,
-    /// This session's attachment, if any. An `Option` here, but reported by
-    /// `handle_list` as a list so the wire can grow to multiple attachments
-    /// without a breaking change. Kept in its own lock rather than in `inner`
-    /// because a client holds `inner` while attached, which would otherwise
-    /// prevent `handle_list` from reading it while a client is attached.
-    pub attachment: Mutex<Option<Attachment>>,
+    pub lifecycle: SessionLifecycle,
     pub child_pid: libc::pid_t,
     pub child_exit_notifier: Arc<ExitNotifier>,
     pub shell_to_client_ctl: Arc<Mutex<ShellToClientCtl>>,

--- a/libshpool/src/template.rs
+++ b/libshpool/src/template.rs
@@ -25,10 +25,14 @@ const VAR_SIZE_GUESS: usize = 40;
 /// by the templated session name feature to allow automatic client
 /// switching.
 ///
-/// The template syntax is that variable subsitutions look like
-/// `#{var_name}`, where var_name must be some alphanumeric string.
+/// The template syntax is that variable substitutions look like `{var_name}`,
+/// where var_name must be some alphanumeric string.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Template {
+    /// The original source string, e.g. `"{workspace}-edit"` or `"htop"`.
+    src: String,
+    /// The parse of `src`, e.g. `[Var("workspace"), Raw("-edit")]` or
+    /// `[Raw("htop")]`.
     chunks: Vec<Chunk>,
     instantiated_size_guess: usize,
 }
@@ -82,7 +86,12 @@ impl Template {
             };
         }
 
-        Ok(Template { chunks, instantiated_size_guess })
+        Ok(Template { src: src.to_string(), chunks, instantiated_size_guess })
+    }
+
+    /// The original source string, e.g. `"{workspace}-edit"` or `"htop"`.
+    pub fn source(&self) -> &str {
+        &self.src
     }
 
     /// Given a variable mapping, instantiate the given template.

--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -205,9 +205,14 @@ pub enum ResizeReply {
 /// to attach to.
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AttachHeader {
-    /// The name of the session to create or attach to.
+    /// The name of the session to create or attach to, e.g. `myproj-edit` or
+    /// `htop`.
     #[serde(default)]
     pub name: String,
+    /// The original session name template before variable substitution, e.g.
+    /// `{workspace}-edit` or `htop`.
+    #[serde(default)]
+    pub name_template: String,
     /// The size of the local tty. Passed along so that the remote
     /// pty can be kept in sync (important so curses applications look
     /// right).
@@ -279,6 +284,23 @@ pub struct Session {
     pub last_disconnected_at_unix_ms: Option<i64>,
     #[serde(default)]
     pub status: SessionStatus,
+    /// This session's attachments. Currently, a session can have at most one
+    /// attachment, but this is a list in case that changes. Maintained
+    /// independently of `status`, so they can briefly disagree.
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+}
+
+/// A session's attachment.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct Attachment {
+    /// The original session name template before variable substitution, e.g.
+    /// `{workspace}-edit` or `htop`.
+    #[serde(default)]
+    pub template: String,
+    /// The pid of the attach process.
+    #[serde(default)]
+    pub pid: i32,
 }
 
 /// Indicates if a shpool session currently has a client attached.

--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -297,7 +297,7 @@ pub struct Attachment {
     /// The original session name template before variable substitution, e.g.
     /// `{workspace}-edit` or `htop`.
     #[serde(default)]
-    pub template: String,
+    pub session_name_template: String,
     /// The pid of the attach process.
     #[serde(default)]
     pub pid: i32,

--- a/shpool/tests/list.rs
+++ b/shpool/tests/list.rs
@@ -3,10 +3,20 @@ use std::process::Command;
 use anyhow::{anyhow, Context};
 use ntest::timeout;
 use regex::Regex;
+use serde_json::Value;
 
 mod support;
 
-use crate::support::daemon::DaemonArgs;
+use crate::support::daemon::{AttachArgs, DaemonArgs};
+
+/// Run `shpool list --json` and return the parsed `sessions` array.
+fn list_sessions(daemon_proc: &mut support::daemon::Proc) -> anyhow::Result<Vec<Value>> {
+    let out = daemon_proc.list_json()?;
+    assert!(out.status.success(), "list --json proc did not exit successfully");
+    let stdout = String::from_utf8_lossy(&out.stdout[..]);
+    let parsed: Value = serde_json::from_str(&stdout).context("parsing JSON output")?;
+    Ok(parsed["sessions"].as_array().ok_or_else(|| anyhow!("missing 'sessions' array"))?.clone())
+}
 
 #[test]
 #[timeout(30000)]
@@ -198,6 +208,323 @@ fn json_output() -> anyhow::Result<()> {
         first_session.get("last_connected_at_unix_ms").is_some(),
         "missing 'last_connected_at_unix_ms' field"
     );
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_literal_name() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+    let bidi_enter_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
+
+    let sess1 = daemon_proc.attach("htop", Default::default())?;
+
+    daemon_proc.events = Some(bidi_enter_w.wait_final_event("daemon-bidi-stream-enter")?);
+
+    let sessions = list_sessions(&mut daemon_proc)?;
+    let session =
+        sessions.iter().find(|s| s["name"] == "htop").ok_or_else(|| anyhow!("htop not found"))?;
+    assert_eq!(session["status"], "Attached");
+
+    let attachments =
+        session["attachments"].as_array().ok_or_else(|| anyhow!("missing attachments array"))?;
+    assert_eq!(attachments.len(), 1, "expected exactly one attachment");
+    // A var-free name still has a template: the literal source string.
+    assert_eq!(attachments[0]["template"], "htop");
+    assert_eq!(attachments[0]["pid"], sess1.proc.id());
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_templated_name() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+    daemon_proc.var_set("workspace", "myproj")?;
+
+    let bidi_enter_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
+
+    let sess1 = daemon_proc.attach("{workspace}-edit", Default::default())?;
+
+    daemon_proc.events = Some(bidi_enter_w.wait_final_event("daemon-bidi-stream-enter")?);
+
+    let sessions = list_sessions(&mut daemon_proc)?;
+    let session = sessions
+        .iter()
+        .find(|s| s["name"] == "myproj-edit")
+        .ok_or_else(|| anyhow!("myproj-edit not found"))?;
+    assert_eq!(session["status"], "Attached");
+
+    let attachments =
+        session["attachments"].as_array().ok_or_else(|| anyhow!("missing attachments array"))?;
+    assert_eq!(attachments.len(), 1, "expected exactly one attachment");
+    // The reported template is the unresolved source, not the resolved name.
+    assert_eq!(attachments[0]["template"], "{workspace}-edit");
+    assert_eq!(attachments[0]["pid"], sess1.proc.id());
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_cleared_on_detach() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+    let bidi_enter_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
+
+    let _sess1 = daemon_proc.attach("sh1", Default::default())?;
+
+    daemon_proc.events = Some(bidi_enter_w.wait_final_event("daemon-bidi-stream-enter")?);
+
+    let sessions = list_sessions(&mut daemon_proc)?;
+    let sh1 =
+        sessions.iter().find(|s| s["name"] == "sh1").ok_or_else(|| anyhow!("sh1 not found"))?;
+    assert_eq!(sh1["status"], "Attached");
+    assert_eq!(sh1["attachments"].as_array().unwrap().len(), 1);
+
+    let out = daemon_proc.detach(vec![String::from("sh1")])?;
+    assert!(out.status.success(), "detach proc did not exit successfully");
+
+    // The status flip (inner-lock release) and attachment clear race the detach RPC
+    // return, so poll until both settle.
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        Ok(sessions.iter().find(|s| s["name"] == "sh1").is_some_and(|sh1| {
+            sh1["status"] == "Disconnected"
+                && sh1["attachments"].as_array().is_some_and(|a| a.is_empty())
+        }))
+    })
+    .context("session should be Disconnected with no attachments after detach")?;
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_survives_var_switch() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+
+    daemon_proc.var_set("env", "prod")?;
+
+    let mut attach_proc =
+        daemon_proc.attach("{env}-session", Default::default()).context("starting attach proc")?;
+    let mut line_matcher = attach_proc.line_matcher()?;
+    attach_proc.run_cmd("echo $SHPOOL_SESSION_NAME")?;
+    line_matcher.scan_until_re("prod-session$")?;
+
+    // The switch re-dials the *same* attach process under the new name, so the
+    // template and pid are unchanged; only the session it lands on changes.
+    let attach_pid = attach_proc.proc.id();
+
+    daemon_proc.var_set("env", "dev")?;
+
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        let prod_ok = sessions.iter().find(|s| s["name"] == "prod-session").is_some_and(|s| {
+            s["status"] == "Disconnected"
+                && s["attachments"].as_array().is_some_and(|a| a.is_empty())
+        });
+        let dev_ok = sessions.iter().find(|s| s["name"] == "dev-session").is_some_and(|s| {
+            s["status"] == "Attached"
+                && s["attachments"].as_array().is_some_and(|a| {
+                    a.len() == 1 && a[0]["template"] == "{env}-session" && a[0]["pid"] == attach_pid
+                })
+        });
+        Ok(prod_ok && dev_ok)
+    })
+    .context("attachment did not move from prod-session to dev-session")?;
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_force_replace() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new(
+        "norc.toml",
+        DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+    )
+    .context("starting daemon proc")?;
+
+    let mut tty1 = daemon_proc.attach("sh1", Default::default()).context("attaching tty1")?;
+    let mut lm1 = tty1.line_matcher()?;
+    tty1.run_cmd("echo up1")?;
+    lm1.scan_until_re("up1$")?;
+    let pid1 = tty1.proc.id();
+
+    let mut tty2 = daemon_proc
+        .attach("sh1", AttachArgs { force: true, ..Default::default() })
+        .context("force-attaching tty2")?;
+    let mut lm2 = tty2.line_matcher()?;
+    tty2.run_cmd("echo up2")?;
+    lm2.scan_until_re("up2$")?;
+    let pid2 = tty2.proc.id();
+    assert_ne!(pid1, pid2, "the two attach procs must have distinct pids");
+
+    // The force-attach replaces tty1's attachment with tty2's; poll because the
+    // detach-then-reattach the force performs is async.
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        Ok(sessions.iter().find(|s| s["name"] == "sh1").is_some_and(|s| {
+            s["status"] == "Attached"
+                && s["attachments"].as_array().is_some_and(|a| a.len() == 1 && a[0]["pid"] == pid2)
+        }))
+    })
+    .context("attachment pid should flip from tty1 to the force-attaching tty2")?;
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_reattach_updates_pid() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+
+    let bidi_done_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-done"]);
+    let pid1;
+    {
+        let mut sess1 = daemon_proc.attach("sh1", Default::default()).context("attaching sh1")?;
+        let mut lm = sess1.line_matcher()?;
+        sess1.run_cmd("echo up")?;
+        lm.scan_until_re("up$")?;
+        pid1 = sess1.proc.id();
+    } // dropping sess1 kills the attach proc
+
+    daemon_proc.events = Some(bidi_done_w.wait_final_event("daemon-bidi-stream-done")?);
+
+    // Once the drop settles, the session lingers as Disconnected with no attachment
+    // (poll: the clear lands after bidi-stream-done, see the detach test).
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        Ok(sessions.iter().find(|s| s["name"] == "sh1").is_some_and(|s| {
+            s["status"] == "Disconnected"
+                && s["attachments"].as_array().is_some_and(|a| a.is_empty())
+        }))
+    })
+    .context("sh1 should be Disconnected with no attachment after the client drops")?;
+
+    // Reattaching is a different process, so the reported pid must update.
+    let mut sess2 = daemon_proc.attach("sh1", Default::default()).context("reattaching sh1")?;
+    let mut lm2 = sess2.line_matcher()?;
+    sess2.run_cmd("echo up2")?;
+    lm2.scan_until_re("up2$")?;
+    let pid2 = sess2.proc.id();
+    assert_ne!(pid1, pid2, "reattach must be a distinct process");
+
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        Ok(sessions.iter().find(|s| s["name"] == "sh1").is_some_and(|s| {
+            s["status"] == "Attached"
+                && s["attachments"].as_array().is_some_and(|a| a.len() == 1 && a[0]["pid"] == pid2)
+        }))
+    })
+    .context("reattachment should report the new client's pid, not the stale one")?;
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_busy_reject_preserves_incumbent() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new(
+        "norc.toml",
+        DaemonArgs { listen_events: false, ..DaemonArgs::default() },
+    )
+    .context("starting daemon proc")?;
+
+    let mut tty1 = daemon_proc.attach("sh1", Default::default()).context("attaching tty1")?;
+    let mut lm1 = tty1.line_matcher()?;
+    tty1.run_cmd("echo up1")?;
+    lm1.scan_until_re("up1$")?;
+    let pid1 = tty1.proc.id();
+
+    // A second, non-force attach is rejected as busy.
+    let mut tty2 = daemon_proc.attach("sh1", Default::default()).context("attaching tty2")?;
+    let mut elm2 = tty2.stderr_line_matcher()?;
+    elm2.scan_until_re("already has a terminal attached$")?;
+    let pid2 = tty2.proc.id();
+
+    // The rejected attach must leave the incumbent's attachment untouched.
+    let sessions = list_sessions(&mut daemon_proc)?;
+    let sh1 =
+        sessions.iter().find(|s| s["name"] == "sh1").ok_or_else(|| anyhow!("sh1 not found"))?;
+    assert_eq!(sh1["status"], "Attached");
+    let attachments =
+        sh1["attachments"].as_array().ok_or_else(|| anyhow!("missing attachments array"))?;
+    assert_eq!(attachments.len(), 1, "busy reject must not add or remove an attachment");
+    assert_eq!(attachments[0]["pid"], pid1, "incumbent attachment pid must be unchanged");
+    assert_ne!(attachments[0]["pid"], pid2, "the rejected client's pid must not appear");
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_per_session_isolation() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+
+    let mut waiter = daemon_proc
+        .events
+        .take()
+        .unwrap()
+        .waiter(["daemon-bidi-stream-enter", "daemon-bidi-stream-enter"]);
+
+    let sess1 = daemon_proc.attach("sh1", Default::default()).context("attaching sh1")?;
+    let sess2 = daemon_proc.attach("sh2", Default::default()).context("attaching sh2")?;
+    waiter.wait_event("daemon-bidi-stream-enter")?;
+    daemon_proc.events = Some(waiter.wait_final_event("daemon-bidi-stream-enter")?);
+
+    let pid1 = sess1.proc.id();
+    let pid2 = sess2.proc.id();
+    assert_ne!(pid1, pid2, "the two attach procs must have distinct pids");
+
+    // Each session must carry its own attachment — not swapped or shared.
+    let sessions = list_sessions(&mut daemon_proc)?;
+    let s1 =
+        sessions.iter().find(|s| s["name"] == "sh1").ok_or_else(|| anyhow!("sh1 not found"))?;
+    let s2 =
+        sessions.iter().find(|s| s["name"] == "sh2").ok_or_else(|| anyhow!("sh2 not found"))?;
+    let a1 = s1["attachments"].as_array().ok_or_else(|| anyhow!("sh1 missing attachments"))?;
+    let a2 = s2["attachments"].as_array().ok_or_else(|| anyhow!("sh2 missing attachments"))?;
+
+    assert_eq!(a1.len(), 1);
+    assert_eq!(a2.len(), 1);
+    assert_eq!(a1[0]["pid"], pid1);
+    assert_eq!(a2[0]["pid"], pid2);
+    assert_eq!(a1[0]["template"], "sh1");
+    assert_eq!(a2[0]["template"], "sh2");
+
+    Ok(())
+}
+
+#[test]
+#[timeout(30000)]
+fn json_attachment_kill_removes_session() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+
+    let bidi_enter_w = daemon_proc.events.take().unwrap().waiter(["daemon-bidi-stream-enter"]);
+    let _sess1 = daemon_proc.attach("sh1", Default::default()).context("attaching sh1")?;
+    daemon_proc.events = Some(bidi_enter_w.wait_final_event("daemon-bidi-stream-enter")?);
+
+    let sessions = list_sessions(&mut daemon_proc)?;
+    assert!(sessions.iter().any(|s| s["name"] == "sh1"), "sh1 should be present before kill");
+
+    let out = daemon_proc.kill(vec![String::from("sh1")])?;
+    assert!(out.status.success(), "kill did not exit successfully");
+
+    // The session and its attachment should vanish from list --json entirely.
+    support::wait_until(|| {
+        let sessions = list_sessions(&mut daemon_proc)?;
+        Ok(!sessions.iter().any(|s| s["name"] == "sh1"))
+    })
+    .context("killed session should disappear from list --json")?;
 
     Ok(())
 }

--- a/shpool/tests/list.rs
+++ b/shpool/tests/list.rs
@@ -232,7 +232,7 @@ fn json_attachment_literal_name() -> anyhow::Result<()> {
         session["attachments"].as_array().ok_or_else(|| anyhow!("missing attachments array"))?;
     assert_eq!(attachments.len(), 1, "expected exactly one attachment");
     // A var-free name still has a template: the literal source string.
-    assert_eq!(attachments[0]["template"], "htop");
+    assert_eq!(attachments[0]["session_name_template"], "htop");
     assert_eq!(attachments[0]["pid"], sess1.proc.id());
 
     Ok(())
@@ -262,7 +262,7 @@ fn json_attachment_templated_name() -> anyhow::Result<()> {
         session["attachments"].as_array().ok_or_else(|| anyhow!("missing attachments array"))?;
     assert_eq!(attachments.len(), 1, "expected exactly one attachment");
     // The reported template is the unresolved source, not the resolved name.
-    assert_eq!(attachments[0]["template"], "{workspace}-edit");
+    assert_eq!(attachments[0]["session_name_template"], "{workspace}-edit");
     assert_eq!(attachments[0]["pid"], sess1.proc.id());
 
     Ok(())
@@ -331,7 +331,9 @@ fn json_attachment_survives_var_switch() -> anyhow::Result<()> {
         let dev_ok = sessions.iter().find(|s| s["name"] == "dev-session").is_some_and(|s| {
             s["status"] == "Attached"
                 && s["attachments"].as_array().is_some_and(|a| {
-                    a.len() == 1 && a[0]["template"] == "{env}-session" && a[0]["pid"] == attach_pid
+                    a.len() == 1
+                        && a[0]["session_name_template"] == "{env}-session"
+                        && a[0]["pid"] == attach_pid
                 })
         });
         Ok(prod_ok && dev_ok)
@@ -497,8 +499,8 @@ fn json_attachment_per_session_isolation() -> anyhow::Result<()> {
     assert_eq!(a2.len(), 1);
     assert_eq!(a1[0]["pid"], pid1);
     assert_eq!(a2[0]["pid"], pid2);
-    assert_eq!(a1[0]["template"], "sh1");
-    assert_eq!(a2[0]["template"], "sh2");
+    assert_eq!(a1[0]["session_name_template"], "sh1");
+    assert_eq!(a2[0]["session_name_template"], "sh2");
 
     Ok(())
 }


### PR DESCRIPTION
## Issue Link

Discussion #378

## AI Policy Ack

Please ack that you have read the [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)
and explain your use of AI to generate this PR.

ack

I vibe coded the initial draft, and then iterated on that with both meats and vibes.

### This PR was:

* [ ] mostly or completely vibe coded
* [ ] mostly or completely meat coded
* [x] bit of both

## Description

In the `shpool list --json` output, add an `attachments` field to each session with each attachment's original `template` string (e.g. `"{workspace}-edit"` or `"htop"`) and its attach proc `pid`. Currently, a session has at most one attachment, but it's provided here as a list in case #40 comes to fruition.

For example,
```sh
$ shpool list --json
{
  "sessions": [
    { "name": "myproj-edit", "status": "Attached",     "attachments": [ { "template": "{workspace}-edit", "pid": 1234 } ], ... },
    { "name": "myproj-term", "status": "Disconnected", "attachments": [],                                                  ... },
    { "name": "htop",        "status": "Attached",     "attachments": [ { "template": "htop",             "pid": 4321 } ], ... }
  ]
}
```

External tools can then check or signal the attach proc using the `pid` field, and relate variables (from `shpool var list`) to sessions and attachments using the `template` field (e.g. a TUI could preview which attachments would respond to a proposed variable change).

Note that, while `attachments` is a list in the JSON output, in the code it's an `Option` (not a `Vec`), to avoid the footgun of e.g. assuming a premature `Vec` will always be of length <= 1. An eventual #40-like change would force an explicit, self-contained migration to `Vec` to pass typechecking. There might even be an argument in favor of making it a nullable field in the JSON, instead of a list.