### PR TITLE
fix: pager EOF lockup bug

### DIFF
--- a/libshpool/src/daemon/pager.rs
+++ b/libshpool/src/daemon/pager.rs
@@ -178,7 +178,9 @@ impl Pager {
         // setting it up to go away when _ctl_guard removes the ctl
         // handle.
         let pty_master_fd = pty_master.raw_fd();
-        init_tty_size.set_fd(pty_master_fd).context("setting init tty size")?;
+        if let Err(e) = init_tty_size.set_fd(pty_master_fd) {
+            warn!("setting init tty size for pager: {:?}", e);
+        }
         let tty_size = Arc::new(Mutex::new(init_tty_size.clone()));
         let tty_size_ref = Arc::clone(&tty_size);
         info!("spawning pager size change listener");
@@ -261,7 +263,11 @@ impl Pager {
                     // the pager process has some data for us
                     let len = pty_master.read(&mut buf).context("reading chunk from pty master")?;
                     if len == 0 {
-                        return Err(anyhow!("EOF from pty while displaying pager"));
+                        info!("pager EOF");
+                        // The pager hung up, which we should treat as a graceful
+                        // exit.
+                        let tty_size = tty_size.lock();
+                        return Ok(tty_size.clone());
                     }
                     let chunk = Chunk { kind: ChunkKind::Data, buf: &buf[..len] };
                     match chunk.write_to(client_stream).and_then(|_| client_stream.flush()) {
@@ -279,8 +285,9 @@ impl Pager {
                 if client_stream_poll_fd.any().unwrap_or(false) {
                     let len = client_stream.read(&mut buf).context("reading client chunk")?;
                     if len == 0 {
-                        info!("EOF");
-                        return Err(anyhow!("EOF from client while displaying pager"));
+                        info!("client EOF");
+                        let tty_size = tty_size.lock();
+                        return Ok(tty_size.clone());
                     }
 
                     trace!("user input: {}", String::from_utf8_lossy(&buf[..len]));

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -1330,7 +1330,7 @@ fn motd_pager() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh1",
     )?;
     // Scan for a fragment of less output.
@@ -1374,7 +1374,7 @@ fn motd_debounced_pager_debounces() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh1",
     )?;
     // scan for a fragment of less output
@@ -1385,7 +1385,7 @@ fn motd_debounced_pager_debounces() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh2",
     )?;
     assert!(!stdout_file_re.is_match(&stdout_str));
@@ -1427,7 +1427,7 @@ fn motd_debounced_pager_unbounces() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh1",
     )?;
     // scan for a fragment of less output
@@ -1441,7 +1441,7 @@ fn motd_debounced_pager_unbounces() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh2",
     )?;
     assert!(stdout_file_re.is_match(&stdout_str));
@@ -1474,7 +1474,7 @@ fn motd_env_test_pager_preserves_term_env_var() -> anyhow::Result<()> {
     let stdout_str = snapshot_attach_output(
         &daemon_proc,
         &config_file,
-        time::Duration::from_millis(500),
+        time::Duration::from_millis(2000),
         "sh1",
     )?;
     // Scan for a fragment of less output.

--- a/shpool/tests/regression.rs
+++ b/shpool/tests/regression.rs
@@ -300,3 +300,37 @@ fn concurrent_attach_to_existing_session_race() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Regression test for a bug where shpool would abort the attach process
+/// if the MOTD pager exited normally (e.g. less EOF). It should transition
+/// to the shell instead.
+#[test]
+#[timeout(15000)]
+fn pager_exit_transitions_to_shell() -> anyhow::Result<()> {
+    let tmp_dir = tmpdir::Dir::new("/tmp/shpool-test")?;
+    let motd_file = tmp_dir.path().join("motd.txt");
+    fs::write(&motd_file, "this is a motd\n")?;
+
+    let config_tmpl = fs::read_to_string(support::testdata_file("motd_pager.toml.tmpl"))?;
+    let config_contents = config_tmpl
+        .replace("TMP_MOTD_MSG_FILE", motd_file.to_str().unwrap())
+        .replace("bin = \"less\"", "bin = \"cat\"");
+    let config_file = tmp_dir.path().join("motd_pager.toml");
+    fs::write(&config_file, config_contents)?;
+
+    let mut daemon_proc = support::daemon::Proc::new(&config_file, DaemonArgs::default())
+        .context("starting daemon proc")?;
+
+    let mut attach_proc =
+        daemon_proc.attach("sh1", Default::default()).context("starting attach proc")?;
+
+    daemon_proc.await_event("daemon-bidi-stream-enter")?;
+
+    let mut line_matcher = attach_proc.line_matcher()?;
+
+    // We should be able to run a command in the shell.
+    attach_proc.run_cmd("echo 'in-shell'")?;
+    line_matcher.scan_until_re("in-shell$")?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Issue Link

n/a

## AI Policy Ack

Ack

### This PR was:

* [ ] mostly or completely vibe coded
* [ ] mostly or completely meat coded
* [X] bit of both

Meat coded the investigation and fix, vibed a regression test.

## Description

51609f8be introduced a regression where shpool would lock up when displaying the message of the day in a pager process like less because it would return an error instead of just terminating the pager display process by returning the current tty size as it ought to have.

This is arguably the first slop bug shpool has had since gemini helped me find the issue that 51609f8be was trying to address, though I wrote the fix that caused the regression. The original CPU pinning EOF bug was real though, it was just my fix that was bad.

I yanked versions 0.10.0 an 0.10.1 over this issue, which might be too extreme now that I have discovered the problem (I think I might be the only person who uses this feature), but at the time I didn't have the cycles to investigate.