### PR TITLE
preserve inherited umask on autodaemonize

### DIFF
--- a/libshpool/src/daemon/mod.rs
+++ b/libshpool/src/daemon/mod.rs
@@ -56,7 +56,19 @@ pub fn run(
             let pid_file = socket.with_file_name("daemonized-shpool.pid");
 
             info!("daemonizing with pid_file={:?}", pid_file);
-            daemonize::Daemonize::new().pid_file(pid_file).start().context("daemonizing")?;
+
+            // Preserve the inherited umask instead of using daemonize's default of 0o027.
+            let inherited_umask = {
+                let current_mask = nix::sys::stat::umask(nix::sys::stat::Mode::empty());
+                nix::sys::stat::umask(current_mask);
+                current_mask.bits() as u32
+            };
+
+            daemonize::Daemonize::new()
+                .pid_file(pid_file)
+                .umask(inherited_umask)
+                .start()
+                .context("daemonizing")?;
         }
     }
 


### PR DESCRIPTION
## AI Policy Ack

Please ack that you have read the [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)
and explain your use of AI to generate this PR.

Ack. An LLM diagnosed this issue when I prompted it to find why the umask was 027 only in shpool. It found it, and generated a fix. Its initial attempt used `unsafe`, but when prompted, it switched to using the `nix` crate. I read `daemonize`'s docs re default mode. I tidied up the code (removed verbose comments, improved variable name).

### This PR was:

* [ ] mostly or completely vibe coded
* [ ] mostly or completely meat coded
* [x] bit of both

## Description

When shpool autodaemonizes, it uses the `daemonize` crate to detach the daemon process. By default, the `daemonize` crate overrides the process umask to `0o027`.

This causes the daemon (and all shells it subsequently spawns) to run with umask `0027`, even if the user launched `shpool attach` with another umask (e.g. `0022`). I noticed this when I saw some tools/workflows break only in shpool.

This change fixes the issue by inherting the umask. The parent is the correct place to decide on umask.

Steps to reproduce:

```
$ umask
0022
$ killall shpool; shpool --socket $(mktemp) attach --cmd "bash -c 'umask; sleep 1s'" foo
0027
```

With this commit:

```
$ umask
0022
$ cargo run -- --socket $(mktemp) attach --cmd "bash -c 'umask; sleep 1s'" foo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/shpool --socket /tmp/tmp.POFOUoQDt2 attach --cmd 'bash -c '\''umask; sleep 1s'\''' foo`
0022
```