### PR TITLE
fix: 0xFF input byte panicking session threads

### DIFF
--- a/libshpool/src/daemon/keybindings.rs
+++ b/libshpool/src/daemon/keybindings.rs
@@ -100,7 +100,8 @@ struct ChordAtom(u8);
 
 impl TrieTab<ChordAtom> for Vec<Option<usize>> {
     fn new() -> Self {
-        vec![None; u8::MAX as usize]
+        // One slot for every possible atom value (0..=255).
+        vec![None; u8::MAX as usize + 1]
     }
 
     fn get(&self, index: ChordAtom) -> Option<&usize> {
@@ -656,6 +657,18 @@ mod test {
         for (src, want) in cases.into_iter() {
             let got = tokenizer.tokenize(src.chars())?;
             assert_eq!(got, want);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_high_input_bytes() -> anyhow::Result<()> {
+        // High bytes, 0xFF in particular, show up in raw input streams
+        // (8-bit meta keys, pasted binary) and must not panic the engine.
+        let mut bindings = Bindings::new(vec![("Ctrl-Space Ctrl-q", Action::Detach)])?;
+        for byte in [0xF0u8, 0xFE, 0xFF] {
+            assert_eq!(bindings.transition(byte), BindingResult::NoMatch);
         }
 
         Ok(())

--- a/libshpool/src/daemon/trie.rs
+++ b/libshpool/src/daemon/trie.rs
@@ -137,7 +137,8 @@ where
 
 impl TrieTab<u8> for Vec<Option<usize>> {
     fn new() -> Self {
-        vec![None; u8::MAX as usize]
+        // One slot for every possible byte value (0..=255).
+        vec![None; u8::MAX as usize + 1]
     }
 
     fn get(&self, index: u8) -> Option<&usize> {

--- a/shpool/tests/attach.rs
+++ b/shpool/tests/attach.rs
@@ -181,6 +181,30 @@ fn forward_env() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Regression test: a high byte (0xFF) in the raw input stream must not
+// kill the session. The keybinding scanner used to index out of bounds
+// on 0xFF, panicking the client->shell thread and disconnecting the
+// client.
+#[test]
+#[timeout(30000)]
+fn high_byte_input_does_not_kill_session() -> anyhow::Result<()> {
+    let mut daemon_proc = support::daemon::Proc::new("norc.toml", DaemonArgs::default())
+        .context("starting daemon proc")?;
+    let mut a1 = daemon_proc.attach("sess", Default::default()).context("starting attach proc")?;
+    let mut lm1 = a1.line_matcher()?;
+
+    a1.run_cmd("echo ready")?;
+    lm1.scan_until_re("ready$")?;
+
+    a1.run_raw(vec![0xFF])?;
+
+    // the session must survive the high byte
+    a1.run_cmd("echo alive")?;
+    lm1.scan_until_re("alive$")?;
+
+    Ok(())
+}
+
 #[test]
 #[timeout(30000)]
 fn symlink_ssh_auth_sock() -> anyhow::Result<()> {


### PR DESCRIPTION
## AI Policy Ack

✅ [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)

This was found using Claude Fable 5.

### This PR was:

✅ completely vibe coded

## Description

Per Fable:  "The Vec-backed trie table allocated u8::MAX (255) slots but indexes with the raw byte value, so byte 0xFF (8-bit meta keys, pasted binary or Latin-1 data) indexed out of bounds and panicked. The keybinding engine feeds every raw client input byte through this trie, so a single 0xFF keystroke killed the client->shell thread and forcibly disconnected the client; the prompt-sentinel scanner feeds raw pty output through the same table, where a panic leaves the session permanently unattachable. Size the table for all 256 byte values (and the chord atom table likewise)."

Fable found this without specific guidance, but this does match a behaviour I've seen sporadically where shpool crashes if a command starts emitting gibberish (e.g. a robot loses the plot and starts dumping arbitrary bytes to stdout).