### PR TITLE
fix: Ctrl-x and Ctrl-y keybinding codes transposed

### DIFF
--- a/libshpool/src/daemon/keybindings.rs
+++ b/libshpool/src/daemon/keybindings.rs
@@ -457,8 +457,8 @@ const CONTROL_CODES: [(&str, u8); 42] = [
     ("Ctrl-u", 21),
     ("Ctrl-v", 22),
     ("Ctrl-w", 23),
-    ("Ctrl-y", 24),
-    ("Ctrl-x", 25),
+    ("Ctrl-x", 24),
+    ("Ctrl-y", 25),
     ("Ctrl-z", 26),
     ("Ctrl-@", 0),
     ("Ctrl-2", 0),
@@ -574,6 +574,18 @@ mod test {
                 panic!("bad success, want err with: {errstr}");
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ctrl_x_and_ctrl_y_codes() -> anyhow::Result<()> {
+        // ASCII control codes: Ctrl-X = CAN = 24, Ctrl-Y = EM = 25
+        let mut bindings = Bindings::new(vec![("Ctrl-x", Action::Detach)])?;
+        assert_eq!(bindings.transition(24), BindingResult::Match(Action::Detach));
+
+        let mut bindings = Bindings::new(vec![("Ctrl-y", Action::Detach)])?;
+        assert_eq!(bindings.transition(25), BindingResult::Match(Action::Detach));
 
         Ok(())
     }


### PR DESCRIPTION
## AI Policy Ack

✅ [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)

Found by Claude Fable 5.

### This PR was:

✅ completely vibe coded

## Description

The control code table mapped Ctrl-y to 24 and Ctrl-x to 25, but the ASCII control codes are Ctrl-X = CAN = 24 and Ctrl-Y = EM = 25 (I'm not sure if there's an _authoritative_ reference for this, but it matches every approach I can find, whether that's the capital-letter-0x40 or letter&0x1F, etc). A keybinding configured with one of these chords fired when the user pressed the other.

Neither Claude nor I could find an obvious reason for this inversion, even though it seems fairly obvious - the letters are simply out of lexical order in the source.  We didn't find anything, but apologies if there's some history here or caveat that requires these to be inverted unusually.