### PR TITLE
fix: compound ttl durations silently parsing as tiny values

### DIFF
--- a/libshpool/src/duration.rs
+++ b/libshpool/src/duration.rs
@@ -64,6 +64,12 @@ fn parse_colon_duration(src: &str) -> anyhow::Result<time::Duration> {
 fn parse_suffix_duration(src: &str) -> anyhow::Result<time::Duration> {
     let num: String = src.chars().take_while(|c| c.is_numeric()).collect();
     let c = src.chars().last().ok_or(anyhow!("internal error: no suffix"))?;
+    // The unit must directly follow the number and end the string,
+    // otherwise compound durations like "1h30m" would silently parse
+    // as 1 minute.
+    if src.chars().count() != num.chars().count() + 1 {
+        bail!("could not parse '{}' as duration", src);
+    }
     make_suffix_duration(num.parse::<u64>().context("parsing num part of duration")?, c)
         .ok_or(anyhow!("unknown time unit '{}'", c))
 }
@@ -113,6 +119,12 @@ mod test {
             ("12x", "unknown time unit"),
             (":1", "parsing minutes part"),
             ("1:1:1:1:1", "cannot have more than 4"),
+            // compound durations are not supported and must not silently
+            // parse as just their first number + last unit
+            ("1h30m", "could not parse"),
+            ("2d12h", "could not parse"),
+            ("12.5h", "could not parse"),
+            ("5x7d", "could not parse"),
         ];
 
         for (src, err_substring) in cases.into_iter() {


### PR DESCRIPTION
## AI Policy Ack

✅ [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)

Found by Claude Fable 5.

### This PR was:

✅ completely vibe coded

## Description

The suffix duration parser took the leading digit run as the value and the last character as the unit, ignoring everything in between, so a natural compound spec like 'shpool attach --ttl 1h30m' parsed as one MINUTE: the reaper killed the session 60 seconds in and the user lost their work. '2d12h' similarly meant 2 hours, '12.5h' meant 12 hours.

Require the unit character to directly follow the digits and end the string, so unsupported compound formats are rejected with an error instead of silently misinterpreted.

**Note**: this doesn't currently allow for whitespace between the digits and the unit, e.g. "1 h".  I could make it tolerate that, if you prefer.

It also will fail for e.g. "1.0h" even though right now it happens to interpret that correctly (by accident).

The better fix might be to support [some] compound durations and floating-point values, like "1.5h" and "1h30m", but that's clearly under "nice to have feature" territory, so I didn't want to just jump to that without knowing if that would actually be desired.