### PR TITLE
fix: /etc/environment keys with underscores being dropped

### DIFF
--- a/libshpool/src/daemon/etc_environment.rs
+++ b/libshpool/src/daemon/etc_environment.rs
@@ -46,7 +46,9 @@ pub fn parse_compat<R: Read>(file: R) -> anyhow::Result<Vec<(String, String)>> {
                     warn!("parsing /etc/environment: empty key");
                     continue;
                 }
-                if !key.chars().all(char::is_alphanumeric) {
+                // pam_env checks `!isalnum(key[i]) && key[i] != '_'`,
+                // so underscores are legal (JAVA_HOME, LC_ALL, ...).
+                if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
                     warn!("parsing /etc/environment: non alphanum key");
                     continue;
                 }
@@ -88,6 +90,7 @@ export  EXPORTED2SPACE=foo
 MISMATCHQUOTE='wut is going on"
 DOUBLEEQUALS=foo=bar
 DOUBLEEQUALSQUOTE='foo=bar'
+JAVA_HOME=/opt/jdk
         "#,
         ))?;
         assert_eq!(
@@ -102,6 +105,9 @@ DOUBLEEQUALSQUOTE='foo=bar'
                 (String::from("MISMATCHQUOTE"), String::from("wut is going on")),
                 (String::from("DOUBLEEQUALS"), String::from("foo=bar")),
                 (String::from("DOUBLEEQUALSQUOTE"), String::from("foo=bar")),
+                // pam_env allows underscores in keys, and most real
+                // /etc/environment entries (JAVA_HOME, LC_ALL, ...) use them
+                (String::from("JAVA_HOME"), String::from("/opt/jdk")),
             ]
         );
 


### PR DESCRIPTION
## AI Policy Ack

✅ [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)

### This PR was:

✅ completely vibe coded

Found by Claude Fable 5.

## Description

The key validation only accepted alphanumeric characters, but pam_env (whose parsing this file explicitly ports) also allows underscores — and almost every real /etc/environment entry (JAVA_HOME, LC_ALL, HTTP_PROXY, XDG_DATA_DIRS, ...) contains one. All such variables were silently missing from shpool sessions while normal ssh/console logins got them. Match pam_env: ascii alphanumerics plus underscore.

This is hypothetical for me - I don't think I've personally run into issues as a result of this - but it does seem like a valid concern; environmental variable keys do often contain underscores and that's explicitly supported in /etc/environment [per the pam_env source](https://github.com/linux-pam/linux-pam/blob/dd62bac17221911106de165607c6925ea54b18d1/modules/pam_env/pam_env.c#L988).  I checked on my Linux work box and indeed bash running inside shpool doesn't have any of the underscored environment variables, whereas bash under SSH does.