### PR TITLE
chore: bump shpool-vterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +316,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -806,6 +824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,11 +1080,12 @@ dependencies = [
 
 [[package]]
 name = "shpool-vterm"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a58af96d28b38601307c0706c52cf1a1e4c2536429c39bbe288738979239d6"
+checksum = "a62077952826e387f18ede8c1fdd115d436b921cf127b4e675430afcc9f0f4d7"
 dependencies = [
  "anyhow",
+ "bitvec",
  "itoa",
  "log",
  "smallvec",
@@ -1161,6 +1186,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1670,6 +1701,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4" # logging facade (not used directly, but required if we have tracing
 tracing = "0.1" # logging and performance monitoring facade
 rmp-serde = "1" # serialization for the control protocol
 shpool_vt100 = "0.1.3" # terminal emulation for the scrollback buffer
-shpool-vterm = "0.1.0" # alt terminal emulation for the scrollback buffer
+shpool-vterm = "0.2.0" # alt terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
 motd = { version = "0.2.2", default-features = false, features = [] } # getting the message-of-the-day
 termini = "1.0.0" # terminfo database


### PR DESCRIPTION
## Issue Link

#46 

## AI Policy Ack

Ack

### This PR was:

* [ ] mostly or completely vibe coded
* [X] mostly or completely meat coded
* [ ] bit of both

## Description

This patch bumps the shpool vterm dep. With this new version, vterm becomes a somewhat usable persistance engine. I haven't done extensive testing, but it will no longer crash.