### PR TITLE
feat: tag shpool-vterms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "shpool-vterm"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62077952826e387f18ede8c1fdd115d436b921cf127b4e675430afcc9f0f4d7"
+checksum = "fe03f99c0b6f0479ed1464eee5af8a478b09f8a117e94c6112bcb92f4364b44d"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/libshpool/Cargo.toml
+++ b/libshpool/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4" # logging facade (not used directly, but required if we have tracing
 tracing = "0.1" # logging and performance monitoring facade
 rmp-serde = "1" # serialization for the control protocol
 shpool_vt100 = "0.1.3" # terminal emulation for the scrollback buffer
-shpool-vterm = "0.2.0" # alt terminal emulation for the scrollback buffer
+shpool-vterm = "0.2.2" # alt terminal emulation for the scrollback buffer
 shell-words = "1" # parsing the -c/--cmd argument
 motd = { version = "0.2.2", default-features = false, features = [] } # getting the message-of-the-day
 termini = "1.0.0" # terminfo database

--- a/libshpool/src/daemon/shell.rs
+++ b/libshpool/src/daemon/shell.rs
@@ -290,7 +290,7 @@ impl SessionInner {
             let _s = span!(Level::INFO, "shell->client", s = name, cid = args.conn_id).entered();
 
             let mut output_spool =
-                session_restore::new(config, &args.tty_size, args.scrollback_lines);
+                session_restore::new(config, &args.tty_size, args.scrollback_lines, &name);
             let mut buf: Vec<u8> = vec![0; consts::BUF_SIZE];
             let mut poll_fds = [poll::PollFd::new(
                 watchable_master.borrow_fd(),

--- a/libshpool/src/session_restore.rs
+++ b/libshpool/src/session_restore.rs
@@ -164,6 +164,7 @@ pub fn new(
     config: config::Manager,
     size: &TtySize,
     scrollback_lines: usize,
+    session_name: &str,
 ) -> Box<dyn SessionSpool + 'static> {
     let restore_engine = config.get().session_restore_engine.clone().unwrap_or_default();
     let mode = config.get().session_restore_mode.clone().unwrap_or_default();
@@ -179,12 +180,13 @@ pub fn new(
             nlines,
             config,
         }),
-        (mode, SessionRestoreEngine::Vterm) => Box::new(Vterm {
-            term: shpool_vterm::Term::new(
+        (mode, SessionRestoreEngine::Vterm) => {
+            let mut term = shpool_vterm::Term::new(
                 scrollback_lines,
                 shpool_vterm::Size { width: size.cols as usize, height: size.rows as usize },
-            ),
-            mode,
-        }),
+            );
+            term.tag(String::from(session_name));
+            Box::new(Vterm { term, mode })
+        }
     }
 }


### PR DESCRIPTION
## Issue Link
https://github.com/shell-pool/shpool/issues/46

## AI Policy Ack

Please ack that you have read the [AI Policy](https://github.com/shell-pool/shpool/blob/master/HACKING.md#ai-policy)
and explain your use of AI to generate this PR.

### This PR was:

* [ ] mostly or completely vibe coded
* [X] mostly or completely meat coded
* [ ] bit of both

## Description

This patch updates shpool so that we start tagging vterm instances with session names. This should make it easier to debug issues with shpool-vterm under real-world usecases.