### PR TITLE
chore: decouple protocol wire version from source

### DIFF
--- a/shpool-protocol/src/lib.rs
+++ b/shpool-protocol/src/lib.rs
@@ -18,7 +18,10 @@ use anyhow::anyhow;
 use clap::ValueEnum;
 use serde_derive::{Deserialize, Serialize};
 
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+// We hardcode the version string to be able to track wire protocol
+// compatibility seperately from rust API compat. For example, adding
+// a new field is wire compatible, but not rust compatible.
+pub const VERSION: &str = "0.4.3";
 
 /// The header used to advertize daemon version.
 ///


### PR DESCRIPTION
## Issue Link

n/a

## AI Policy Ack

Ack

### This PR was:

* [ ] mostly or completely vibe coded
* [X] mostly or completely meat coded
* [ ] bit of both

## Description

This patch decouples the shpool-protocol wire format version number from the source code version number. Some updates are backwards compatible at the wire level but not at the source level, and a breaking update at the wire level is very disruptive so we want to avoid it as much as we can.